### PR TITLE
Tweaks to use Mongrel's parser directly

### DIFF
--- a/ext/java/jruby_thin.rb
+++ b/ext/java/jruby_thin.rb
@@ -1,0 +1,6 @@
+require 'http11'
+
+module Thin
+  include Mongrel
+  InvalidRequest = HttpParserError
+end

--- a/lib/thin.rb
+++ b/lib/thin.rb
@@ -46,6 +46,8 @@ rescue LoadError
   if RUBY_PLATFORM =~ /mingw|mswin/ then
     RUBY_VERSION =~ /(\d+.\d+)/
     require "#{Thin::ROOT}/#{$1}/thin_parser"
+  elsif RUBY_PLATFORM =~ /java/ then
+    require 'java/jruby_thin'
   end
 end
 


### PR DESCRIPTION
I know this isn't the way we'd want to do it, but this gets Thin to work on JRuby without a native extension requirement.

The right way would be to get Mongrel's http11 extension spun off as a separate gem that both Mongrel and Thin can depend upon.

It would be nice to have Thin "just work" on JRuby without cext hassles...
