### PR TITLE
Adjusting unix socket permissions to be more open.

### DIFF
--- a/lib/thin/backends/unix_server.rb
+++ b/lib/thin/backends/unix_server.rb
@@ -14,7 +14,7 @@ module Thin
       # Connect the server
       def connect
         at_exit { remove_socket_file } # In case it crashes
-        old_umask = File.umask(opt[:umask] || 0)
+        old_umask = File.umask(0)
         begin
           EventMachine.start_unix_domain_server(@socket, UnixConnection, &method(:initialize_connection))
           # HACK EventMachine.start_unix_domain_server doesn't return the connection signature


### PR DESCRIPTION
I stole the lines from unicorn, it sets the umask to 0000 before creating the socket, and restores it afterwards.

Unicorn has an option to specify the umask, but I was unable to hook into the objects, maybe someone more familiar with thin can do it.

Feel free to merge or comment this!
