### PR TITLE
Handle 1xx status codes better by not closing the connection

### DIFF
--- a/lib/thin/response.rb
+++ b/lib/thin/response.rb
@@ -7,6 +7,8 @@ module Thin
     SERVER         = 'Server'.freeze
     CONTENT_LENGTH = 'Content-Length'.freeze
 
+    PERSISTENT_STATUSES  = [100, 101].freeze
+
     # Status code
     attr_accessor :status
 
@@ -93,9 +95,10 @@ module Thin
     end
 
     # Persistent connection must be requested as keep-alive
-    # from the server and have a Content-Length.
+    # from the server and have a Content-Length, or the response
+    # status must require that the connection remain open.
     def persistent?
-      @persistent && @headers.has_key?(CONTENT_LENGTH)
+      (@persistent && @headers.has_key?(CONTENT_LENGTH)) || PERSISTENT_STATUSES.include?(@status)
     end
   end
 end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -80,6 +80,17 @@ describe Response do
     @response.should_not be_persistent
   end
   
+  it "should be persistent when the status code implies it should stay open" do
+    @response = Response.new
+    @response.status = 100
+    # "There are no required headers for this class of status code" -- HTTP spec 10.1
+    @response.body = ''
+
+    # Specifying it as persistent in the code is NOT required
+    # @response.persistent!
+    @response.should be_persistent
+  end
+  
   it "should be persistent when specified" do
     @response.persistent!
     @response.should be_persistent


### PR DESCRIPTION
The 100 and 101 status codes need the connection to remain open in order to comply with their descriptions in the spec. See sections 10.1 and section 8.2.3.  There may be other places in the spec that support this idea as well.

Thanks! :-)
