### PR TITLE
shut down gracefully when receiving SIGTERM

### DIFF
--- a/lib/thin/server.rb
+++ b/lib/thin/server.rb
@@ -214,7 +214,7 @@ module Thin
       # * TERM calls <tt>stop!</tt> to force shutdown.
       def setup_signals
         trap('INT')  { stop! }
-        trap('TERM') { stop! }
+        trap('TERM') { stop }
         unless Thin.win?
           trap('QUIT') { stop }
           trap('HUP')  { restart }


### PR DESCRIPTION
Processes are allowed a chance to shut down gracefully when receiving SIGTERM[1].

On Heroku, when shutting down a process, we send a SIGTERM followed 10 seconds later with a SIGKILL, similar to the behavior of the init daemon on most Unix systems.  This patch will allow Heroku apps to shut down gracefully when they need to be terminated / moved.

1: http://en.wikipedia.org/wiki/SIGTERM
