### PR TITLE
removed Specification#has_rdoc= assignment, this method has been deprecat

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -13,7 +13,6 @@ Thin::GemSpec = Gem::Specification.new do |s|
   s.email                 = 'macournoyer@gmail.com'
   s.homepage              = 'http://code.macournoyer.com/thin/'
   s.rubyforge_project     = 'thin'
-  s.has_rdoc              = true
   s.executables           = %w(thin)
 
   s.required_ruby_version = '>= 1.8.5'


### PR DESCRIPTION
removed Specification#has_rdoc= assignment, this method has been deprecated in RubyGems 1.8+ and [defaults to true](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb#L1267). This squashes warnings spit out by RubyGems
