### PR TITLE
Logger#log_error prints to STDERR

### DIFF
--- a/lib/thin/logging.rb
+++ b/lib/thin/logging.rb
@@ -46,7 +46,7 @@ module Thin
     
     # Log an error backtrace if debugging is activated
     def log_error(e=$!)
-      debug "#{e}\n\t" + e.backtrace.join("\n\t")
+      STDERR.print("#{e}\n\t" + e.backtrace.join("\n\t")) if Logging.debug?
     end
     module_function :log_error
     public :log_error

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -39,6 +39,12 @@ describe Logging do
     Logging.silent = true
     Logging.log "hi"
   end
+
+  it "should print errors to STDERR" do
+    error = mock(:error, :backtrace => Array("PC LOAD LETTER"))
+    STDERR.should_receive(:print).with(/PC LOAD LETTER/)
+    @object.log_error(error)
+  end
   
   after do
     Logging.silent = true


### PR DESCRIPTION
Hello,

Would it not be preferable to output errors to STDERR?

This is the conventional output stream for errors. Also other tools expect backtraces etc. to be sent there (see http://stackoverflow.com/questions/4627928/get-rails-exceptions-to-show-using-capybara-and-selenium).

Cheers,
Dave
