### PR TITLE
Make set_content_length work for every valid rack spec. Couldn't find app

### DIFF
--- a/lib/thin/connection.rb
+++ b/lib/thin/connection.rb
@@ -224,6 +224,14 @@ module Thin
              bytes += p.respond_to?(:bytesize) ? p.bytesize : p.size
            end
            headers[CONTENT_LENGTH] = bytes.to_s
+        else
+          bytes, nbody = 0, []
+          body.each do |p|
+            bytes += p.respond_to?(:bytesize) ? p.bytesize : p.size
+            nbody << p
+          end
+          headers[CONTENT_LENGTH] = bytes.to_s
+          result[2] = nbody
         end
       end
   end


### PR DESCRIPTION
Make set_content_length work for every valid rack spec. Couldn't find appropriate test - maybe i'm blind.
