### PR TITLE
Add detection of Mac ruby version

### DIFF
--- a/lib/thin/version.rb
+++ b/lib/thin/version.rb
@@ -26,6 +26,10 @@ module Thin
     RUBY_PLATFORM =~ /linux/
   end
   
+  def self.mac?
+    RUBY_PLATFORM =~ /darwin/
+  end
+  
   def self.ruby_18?
     RUBY_VERSION =~ /^1\.8/
   end


### PR DESCRIPTION
Will be required for some POSIX-system commands like "install" (see issue #63)
