### PR TITLE
rack specifies a way to stream static files

### DIFF
--- a/lib/thin/connection.rb
+++ b/lib/thin/connection.rb
@@ -101,10 +101,15 @@ module Thin
       @response.persistent! if @request.persistent?
 
       # Send the response
-      @response.each do |chunk|
-        trace { chunk }
-        send_data chunk
+      sendfile = true
+      catch :streamfile do # this is full of spaghetti
+        @response.each do |chunk|
+          trace { chunk }
+          send_data chunk
+        end
+        sendfile = false
       end
+      send_file_data @response.body.to_path if sendfile
 
     rescue Exception
       handle_error

--- a/lib/thin/response.rb
+++ b/lib/thin/response.rb
@@ -84,6 +84,8 @@ module Thin
       yield head
       if @body.is_a?(String)
         yield @body
+      elsif @body.respond_to?(:to_path)
+        throw :streamfile
       else
         @body.each { |chunk| yield chunk }
       end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -66,6 +66,19 @@ describe Response do
     @response.each { |l| out << l }
     out.should include("\r\n\r\n<html></html>")
   end
+
+  it 'should throw :streamfile body' do
+    @response.body = Struct.new(:to_path).new('foobar')
+    
+    out = ''
+    streamed = true
+    catch :streamfile do
+      @response.each { |l| out << l }
+      streamed = false
+    end
+    streamed.should be_true
+    out.should include("\r\n\r\n")
+  end
     
   it "should not be persistent by default" do
     @response.should_not be_persistent


### PR DESCRIPTION
If the Body responds to to_path, it must return a String identifying the location of a file whose contents are identical to that produced by calling each; this may be used by the server as an alternative, possibly more efficient way to transport the response. The Body commonly is an Array of Strings, the application instance itself, or a File-like object. 
