### PR TITLE
Support 'Transfer-Encoding: chunked' for input data

### DIFF
--- a/spec/request/processing_spec.rb
+++ b/spec/request/processing_spec.rb
@@ -47,4 +47,16 @@ describe Request, 'processing' do
     pending("Ruby 1.9 compatible implementations only") unless StringIO.instance_methods.include? :external_encoding
     Request.new.body.external_encoding.should == Encoding::ASCII_8BIT
   end
+
+  it "should accept chunked transfer encoding for input stream" do
+    chunk_sizes = [42, 8192, 1, 0]
+    request = Request.new
+    request.parse("PUT /postit HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n")
+    chunk_sizes.each do |size|
+      request.parse("#{size.to_s(16)}\r\n#{'X' * size}\r\n")
+    end
+
+    request.body.size.should == chunk_sizes.inject(0) { |sum, i| sum + i }
+    request.should be_finished
+  end
 end


### PR DESCRIPTION
This is a bit esoteric, since it's specifically to support MacOS X's built-in WebDAV remote file system, which uses non-standard chunked PUT requests -- but it's the only way to use Thin to write a WebDAV server that will work with it. :-)

For what it's worth, Apache supports this transfer encoding. And it's the only way to stream data to a server without knowing the length beforehand. So I think it's a reasonable thing to support.
