### PR TITLE
add a newline to log_error so the stack trace doesn't run into the next line

### DIFF
--- a/lib/thin/logging.rb
+++ b/lib/thin/logging.rb
@@ -46,7 +46,7 @@ module Thin
     
     # Log an error backtrace if debugging is activated
     def log_error(e=$!)
-      STDERR.print("#{e}\n\t" + e.backtrace.join("\n\t")) if Logging.debug?
+      STDERR.print("#{e}\n\t" + e.backtrace.join("\n\t") + "\n") if Logging.debug?
     end
     module_function :log_error
     public :log_error


### PR DESCRIPTION
otherwise the log looks like this:

```
    /Users/alex/.rvm/gems/ruby-1.9.2-p290/bin/rackup:19:in `<main>'127.0.0.1 - - [12/Jan/2012 09:42:00] "GET /font/opensans.css HTTP/1.1" 304 - 0.0008
```
