### PR TITLE
Rails will never been choose as adapter for most of the rails apps

### DIFF
--- a/lib/rack/adapter/loader.rb
+++ b/lib/rack/adapter/loader.rb
@@ -8,8 +8,8 @@ module Rack
   # NOTE: If a framework has a file that is not unique, make sure to place
   # it at the end.
   ADAPTERS = [
-    [:rack,    'config.ru'],
     [:rails,   'config/environment.rb'],
+    [:rack,    'config.ru'],
     [:ramaze,  'start.rb'],
     [:halcyon, 'runner.ru'],
     [:merb,    'config/init.rb'],


### PR DESCRIPTION
Most of the rails app have a config.ru so if you validate first config.ru instead of enviroment.rb
