### PR TITLE
Pass RACK_ENV or RAILS_ENV back to Rack

### DIFF
--- a/lib/thin/runner.rb
+++ b/lib/thin/runner.rb
@@ -33,7 +33,7 @@ module Thin
       # Default options values
       @options = {
         :chdir                => Dir.pwd,
-        :environment          => 'development',
+        :environment          => ENV['RACK_ENV'] || 'development',
         :address              => '0.0.0.0',
         :port                 => Server::DEFAULT_PORT,
         :timeout              => Server::DEFAULT_TIMEOUT,


### PR DESCRIPTION
If initialized with RACK_ENV or RAILS_ENV set, thin will overwrite them and default to 'development' unless they were passed in directly through the `-e` option. This simple will use RACK_ENV if set, or default back to 'development' if no env vars are present.
