### PR TITLE
Restart thins one by one.

### DIFF
--- a/example/vlad.rake
+++ b/example/vlad.rake
@@ -53,7 +53,7 @@ configuration is set via the thin_* variables.".cleanup
   desc "Restart the app servers"
 
   remote_task :start_app, :roles => :app do
-    run thin("restart -s #{thin_servers}")
+    run thin("restart -O -s #{thin_servers}")
   end
 
   desc "Stop the app servers"


### PR DESCRIPTION
I proposed this change on /phs/vlad-thin, he said I should come here first. As far as I know, there is no disadvantage to using -O in thin restart and plenty of benefit in terms of availability.
