### PR TITLE
Add site adapter.

### DIFF
--- a/lib/rack/adapter/loader.rb
+++ b/lib/rack/adapter/loader.rb
@@ -65,10 +65,35 @@ module Rack
         
       when :file
         return Rack::File.new(options[:chdir])
-        
+
+      when :site
+        return Rack::Builder.new do
+          use Index, :root=>options[:chdir]
+          run Rack::Directory.new(options[:chdir])  
+        end
+
       else
         raise AdapterNotFound, "Adapter not found: #{name}"
         
+      end
+    end
+  end
+
+  # Rack middleware to serve an index file by default (e.g. `index.html`).
+  class Index
+    def initialize(app, options={})
+      @app   = app
+      @root  = options[:root]  || Dir.pwd
+      @index = options[:index] || 'index.html'
+    end
+
+    def call(env)
+      path = Rack::Utils.unescape(env['PATH_INFO'])
+      index_file = ::File.join(@root, path, @index)
+      if ::File.exists?(index_file)
+        [200, {'Content-Type' => 'text/html'}, ::File.new(index_file)]
+      else
+        @app.call(env)
       end
     end
   end


### PR DESCRIPTION
This is a working "site" adapter. It works much like the file adapter but will serve a default index file (index.html) when directory paths are requested.
