### PR TITLE
change PID file ownership to match process ownership so stop can remove PID files

### DIFF
--- a/lib/thin/daemonizing.rb
+++ b/lib/thin/daemonizing.rb
@@ -72,6 +72,9 @@ module Thin
       target_gid = Etc.getgrnam(group).gid
 
       if uid != target_uid || gid != target_gid
+        # Change PID file ownership
+        File.chown(target_uid, target_gid, @pid_file)
+
         # Change process ownership
         Process.initgroups(user, target_gid)
         Process::GID.change_privilege(target_gid)


### PR DESCRIPTION
Currently when thin is started as root but drops root privileges due to thin config the PID files are owned by root:root.  This prevents thin stop from removing the PID files since the processes no longer have root privileges.  

This patch adjusts the PID files to match the new user and group before dropping the privileges used to create the PID files.
