### PR TITLE
Make proper response on exception

### DIFF
--- a/lib/thin/response.rb
+++ b/lib/thin/response.rb
@@ -9,6 +9,11 @@ module Thin
 
     PERSISTENT_STATUSES  = [100, 101].freeze
 
+    #Error Responses
+    ERROR            = [500, {'Content-Type' => 'text/plain'}, ['Internal server error']].freeze
+    PERSISTENT_ERROR = [500, {'Content-Type' => 'text/plain', 'Connection' => 'keep-alive', 'Content-Length' => "21"}, ['Internal server error']].freeze
+    BAD_REQUEST      = [400, {'Content-Type' => 'text/plain'}, ['Bad Request']].freeze
+
     # Status code
     attr_accessor :status
 


### PR DESCRIPTION
Thin server close connection without response when exception handled in connection. This change use following approach for exception handling:
- invalid request  - respond with 400(Bad request) and close connection including persistent one
- `pre_process` exception including unhanded app one - respond with 500(Internal server error) and do not close persistent connections.
- `post_process` - no response, close connection
