### PR TITLE
Ignore Content-Length header case in response

### DIFF
--- a/lib/thin/headers.rb
+++ b/lib/thin/headers.rb
@@ -3,7 +3,7 @@ module Thin
   # and allow duplicated entries on some names.
   class Headers
     HEADER_FORMAT      = "%s: %s\r\n".freeze
-    ALLOWED_DUPLICATES = %w(Set-Cookie Set-Cookie2 Warning WWW-Authenticate).freeze
+    ALLOWED_DUPLICATES = %w(set-cookie set-cookie2 warning www-authenticate).freeze
     
     def initialize
       @sent = {}
@@ -14,8 +14,8 @@ module Thin
     # Ignore if already sent and no duplicates are allowed
     # for this +key+.
     def []=(key, value)
-      if !@sent.has_key?(key) || ALLOWED_DUPLICATES.include?(key)
-        @sent[key] = true
+      if !@sent.has_key?(key) || ALLOWED_DUPLICATES.include?(key.downcase)
+        @sent[key.downcase] = true
         value = case value
                 when Time
                   value.httpdate
@@ -29,7 +29,7 @@ module Thin
     end
     
     def has_key?(key)
-      @sent[key]
+      @sent[key.downcase]
     end
     
     def to_s

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -73,13 +73,22 @@ describe Response do
   
   it "should not be persistent when no Content-Length" do
     @response = Response.new
-    @response.headers['Content-Type'] = 'text/html'
+    @response.headers = {'Content-Type' => 'text/html'}
     @response.body = ''
     
     @response.persistent!
     @response.should_not be_persistent
   end
-  
+
+  it "should ignore Content-Length case" do
+    @response = Response.new
+    @response.headers = {'Content-Type' => 'text/html', 'content-length' => '0'}
+    @response.body = ''
+
+    @response.persistent!
+    @response.should be_persistent
+  end
+
   it "should be persistent when the status code implies it should stay open" do
     @response = Response.new
     @response.status = 100


### PR DESCRIPTION
According to the [RFC2616](http://pretty-rfc.herokuapp.com/RFC2616#message.headers)

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive. 

Header spelled other than "Content-Length" prevents response to be persistent. Also that prevents header duplicates that have different case: "X-HOST" and "X-Host" for instance.
