### PR TITLE
Allow rbx to fail in 1.8 & 1.9 modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - rbx
-  - rbx-2.0
+  - rbx-18mode
+  - rbx-19mode
   - jruby
   - ree
+matrix:
+  allow_failures:
+    - rvm: rbx-18mode
+    - rvm: rbx-19mode
 notifications:
   email: false


### PR DESCRIPTION
In support of rubinius/rubinius#2006

If they both pass on first run then it'd be nice to remove
the allowed failure.
