### PR TITLE
Fix JRuby key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 1.9.3
   - rbx-18mode
   - rbx-19mode
-  - jruby
+  - jruby-18mode
   - ree
 matrix:
   allow_failures:


### PR DESCRIPTION
I checked the file with [the Travis lint](http://lint.travis-ci.org/macournoyer/thin) checker 
and it prefers `jruby-18mode` to just `jruby`
