### PR TITLE
Added possibility to start, stop and restart only one instance

### DIFF
--- a/lib/thin/controllers/service.sh.erb
+++ b/lib/thin/controllers/service.sh.erb
@@ -20,18 +20,24 @@ CONFIG_PATH=<%= config_files_path %>
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
 
+if [ "X$2" = X ] || [ "X$3" = X ]; then
+    INSTANCES="--all $CONFIG_PATH"
+else
+    INSTANCES="-C $3"
+fi
+
 case "$1" in
   start)
-	$DAEMON start --all $CONFIG_PATH
-	;;
+  $DAEMON start $INSTANCES
+  ;;
   stop)
-	$DAEMON stop --all $CONFIG_PATH
-	;;
+  $DAEMON stop $INSTANCES
+  ;;
   restart)
-	$DAEMON restart --all $CONFIG_PATH
+  $DAEMON restart $INSTANCES
 	;;
   *)
-	echo "Usage: $SCRIPT_NAME {start|stop|restart}" >&2
+	echo "Usage: $SCRIPT_NAME {start|stop|restart} [-C $CONFIG_PATH/your_website.yml]" >&2
 	exit 3
 	;;
 esac


### PR DESCRIPTION
There certainly should be an opportunity to start, stop and restart only that server instances which user needs. For example, user configures server instances using thin config -C file.yml. So it would be great to make the same for start, restart and stop actions.
