### PR TITLE
Replace obsolete Rake::RDocTask with RDoc::Task

### DIFF
--- a/tasks/rdoc.rake
+++ b/tasks/rdoc.rake
@@ -1,18 +1,18 @@
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 CLEAN.include %w(doc/rdoc)
 
-Rake::RDocTask.new do |rdoc|
+RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = 'doc/rdoc'
   rdoc.options += ['--quiet', '--title', Thin::NAME,
              	     "--opname", "index.html",
             	     "--line-numbers",
-            	     "--main", "README",
+            	     "--main", "README.md",
             	     "--inline-source"]
   rdoc.template = "site/rdoc.rb"
-  rdoc.main = "README"
+  rdoc.main = "README.md"
   rdoc.title = Thin::NAME
-  rdoc.rdoc_files.add %w(README) +
+  rdoc.rdoc_files.add %w(README.md) +
                       FileList['lib/**/*.rb'] +
                       FileList['bin/*']
 end


### PR DESCRIPTION
Replace obsolete Rake::RDocTask with RDoc::Task and updated RDoc task to point to correct README file (README.md). 
