### PR TITLE
Fixes problem with connections requests keep-alive and thin

### DIFF
--- a/lib/thin/connection.rb
+++ b/lib/thin/connection.rb
@@ -36,7 +36,10 @@ module Thin
     def receive_data(data)
       @idle = false
       trace { data }
-      process if @request.parse(data)
+      if @request.parse(data)
+        process
+        @request = Thin::Request.new if persistent?
+      end
     rescue InvalidRequest => e
       log "!! Invalid request"
       log_error e

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -60,6 +60,15 @@ describe Connection do
     @connection.should_receive(:teminate_request).never
     @connection.process
   end
+  
+  it "should create a new request after parsing complete with persistend connection" do
+    prev_request = @connection.request.object_id
+    @connection.request.should_receive(:parse).and_return(true)
+    @connection.stub!(:persistent?).and_return(true)
+    @connection.should_receive(:process)
+    @connection.receive_data('GET')
+    @connection.request.object_id.should_not == prev_request
+  end
 
   it "should rescue Timeout error in process" do
     @connection.app.should_receive(:call).and_raise(Timeout::Error.new("timeout error not rescued"))

--- a/spec/server/pipelining_spec.rb
+++ b/spec/server/pipelining_spec.rb
@@ -11,6 +11,14 @@ describe Server, "HTTP pipelining" do
       [200, { 'Content-Type' => 'text/html',  'Content-Length' => (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s }, body]
     end
     @server.maximum_persistent_connections = 1024
+
+    # wait until the server is reachable
+    begin
+      TCPSocket.new('0.0.0.0', 3333).close
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      sleep 0.1
+      retry
+    end
   end
 
   it "should pipeline request on same socket" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,11 @@ end
 module Matchers
   class BeFasterThen
     def initialize(max_time)
-      require 'benchmark_unit'
       @max_time = max_time
+    end
+
+    def measure(&block)
+      Benchmark.measure(&block).total
     end
 
     # Base on benchmark_unit/assertions#compare_benchmarks
@@ -30,20 +33,16 @@ module Matchers
       @time, multiplier = 0, 1
       
       while (@time < 0.01) do
-        @time = Benchmark::Unit.measure do 
-          multiplier.times &proc
-        end
+        @time = measure { multiplier.times &proc }
         multiplier *= 10
       end
       
       multiplier /= 10
       
-      iterations = (Benchmark::Unit::CLOCK_TARGET / @time).to_i * multiplier
+      iterations = (2 / @time).to_i * multiplier
       iterations = 1 if iterations < 1
       
-      total = Benchmark::Unit.measure do 
-        iterations.times &proc
-      end
+      total = measure { iterations.times &proc }
       
       @time = total / iterations
       


### PR DESCRIPTION
@alebsack and I discovered that the env in thin is shared across many calls in a keep-alive session. This is causing problems in the levels above. Especially if the requests are processed concurrent and two are using the same rack `env`. The new **thin v2** uses the `on_message_begin ` to create the request object every time a request is made (this is done by *http_parser.rb*). This pull request will create a new request object for every request that is made on persistent connections, which fixes the problem vor 1.5.x also