### PR TITLE
Threadpool size setting

### DIFF
--- a/lib/thin/backends/base.rb
+++ b/lib/thin/backends/base.rb
@@ -22,11 +22,18 @@ module Thin
       
       # Maximum number of connections that can be persistent
       attr_accessor :maximum_persistent_connections
-      
+
+      #allows setting of the eventmachine threadpool size
+      attr_reader :threadpool_size
+      def threadpool_size=(size)
+        @threadpool_size = size
+        EventMachine.threadpool_size = size
+      end
+
       # Allow using threads in the backend.
       attr_writer :threaded
       def threaded?; @threaded end
-      
+            
       # Allow using SSL in the backend.
       attr_writer :ssl, :ssl_options
       def ssl?; @ssl end

--- a/lib/thin/controllers/controller.rb
+++ b/lib/thin/controllers/controller.rb
@@ -37,7 +37,7 @@ module Thin
       def start
         # Constantize backend class
         @options[:backend] = eval(@options[:backend], TOPLEVEL_BINDING) if @options[:backend]
-        
+
         server = Server.new(@options[:socket] || @options[:address], # Server detects kind of socket
                             @options[:port],                         # Port ignored on UNIX socket
                             @options)
@@ -50,6 +50,7 @@ module Thin
         server.maximum_persistent_connections = @options[:max_persistent_conns]
         server.threaded                       = @options[:threaded]
         server.no_epoll                       = @options[:no_epoll] if server.backend.respond_to?(:no_epoll=)
+        server.threadpool_size                = @options[:threadpool_size] if server.threaded?
 
         # ssl support
         if @options[:ssl]

--- a/lib/thin/request.rb
+++ b/lib/thin/request.rb
@@ -128,7 +128,7 @@ module Thin
     def threaded=(value)
       @env[RACK_MULTITHREAD] = value
     end
-    
+
     def async_callback=(callback)
       @env[ASYNC_CALLBACK] = callback
       @env[ASYNC_CLOSE] = EventMachine::DefaultDeferrable.new

--- a/lib/thin/runner.rb
+++ b/lib/thin/runner.rb
@@ -42,7 +42,8 @@ module Thin
         :max_conns            => Server::DEFAULT_MAXIMUM_CONNECTIONS,
         :max_persistent_conns => Server::DEFAULT_MAXIMUM_PERSISTENT_CONNECTIONS,
         :require              => [],
-        :wait                 => Controllers::Cluster::DEFAULT_WAIT_TIME
+        :wait                 => Controllers::Cluster::DEFAULT_WAIT_TIME,
+        :threadpool_size      => 20
       }
 
       parse!
@@ -124,6 +125,8 @@ module Thin
                                        "(default: #{@options[:max_persistent_conns]})") { |num| @options[:max_persistent_conns] = num.to_i }
         opts.on(      "--threaded", "Call the Rack application in threads " +
                                     "[experimental]")                                   { @options[:threaded] = true }
+        opts.on(      "--threadpool_size NUM", "Sets the size of the EventMachine threadpool.",
+                                       "(default: #{@options[:threadpool_size]})") { |num| @options[:threadpool_size] = num.to_i }
         opts.on(      "--no-epoll", "Disable the use of epoll")                         { @options[:no_epoll] = true } if Thin.linux?
 
         opts.separator ""

--- a/lib/thin/server.rb
+++ b/lib/thin/server.rb
@@ -80,7 +80,7 @@ module Thin
     def_delegators :backend, :maximum_persistent_connections, :maximum_persistent_connections=
     
     # Allow using threads in the backend.
-    def_delegators :backend, :threaded?, :threaded=
+    def_delegators :backend, :threaded?, :threaded=, :threadpool_size, :threadpool_size=
     
     # Allow using SSL in the backend.
     def_delegators :backend, :ssl?, :ssl=, :ssl_options=

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -29,6 +29,11 @@ describe Server do
     @server.threaded = true
     @server.backend.should be_threaded
   end
+
+  it "should set the threadpool" do
+    @server.threadpool_size = 10
+    @server.threadpool_size.should == 10
+  end
 end
 
 describe Server, "initialization" do


### PR DESCRIPTION
ActiveRecord tends to really misbehave when run in threaded mode and not being careful with the connection pool. So on Rails when I run it in thread-safe mode I add middleware to grab a connection for each thread. The problem is with thin running on normal eventmachine that means I need a connection pool of 20 to mysql.
This let's you shrink down the number of eventmachine threads so you can have a smaller connection pool.
