### PR TITLE
thin install - systemD support

### DIFF
--- a/lib/thin/controllers/service.rb
+++ b/lib/thin/controllers/service.rb
@@ -6,58 +6,78 @@ module Thin
     # config files are in a directory.
     class Service < Controller
       INITD_PATH          = File.directory?('/etc/rc.d') ? '/etc/rc.d/thin' : '/etc/init.d/thin'
+      SYSTEMD_PATH        = '/usr/lib/systemd/system/thin.service'
       DEFAULT_CONFIG_PATH = '/etc/thin'
-      TEMPLATE            = File.dirname(__FILE__) + '/service.sh.erb'
-    
+      SYSTEMD             = File.exist?('/bin/systemctl')
+
       def initialize(options)
         super
-      
+
         raise PlatformNotSupported, 'Running as a service only supported on Linux' unless Thin.linux?
       end
-    
+
       def config_path
         @options[:all] || DEFAULT_CONFIG_PATH
       end
-    
+
       def start
         run :start
       end
-    
+
       def stop
         run :stop
       end
-    
+
       def restart
         run :restart
       end
-    
+
       def install(config_files_path=DEFAULT_CONFIG_PATH)
-        if File.exist?(INITD_PATH)
-          log ">> Thin service already installed at #{INITD_PATH}"
-        else
-          log ">> Installing thin service at #{INITD_PATH} ..."
-          sh "mkdir -p #{File.dirname(INITD_PATH)}"
-          log "writing #{INITD_PATH}"        
-          File.open(INITD_PATH, 'w') do |f|
-            f << ERB.new(File.read(TEMPLATE)).result(binding)
-          end
-          sh "chmod +x #{INITD_PATH}" # Make executable
-        end
-      
+		if SYSTEMD
+			template = File.dirname(__FILE__) + '/thin.service.erb'
+			if File.exist?(SYSTEMD_PATH)
+			  log ">> Thin SystemD service file already installed. Aborting."
+			else
+			  log ">> Installing thin service file at #{SYSTEMD_PATH} ..."
+			  File.open(SYSTEMD_PATH, 'w') do |f|
+				f << ERB.new(File.read(template)).result(binding)
+			  end
+			end
+		else # INITD
+			template = File.dirname(__FILE__) + '/service.sh.erb'
+			if File.exist?(INITD_PATH)
+			  log ">> Thin service already installed at #{INITD_PATH}. Aborting."
+			else
+			  log ">> Installing thin service at #{INITD_PATH} ..."
+			  sh "mkdir -p #{File.dirname(INITD_PATH)}"
+			  log "writing #{INITD_PATH}"
+			  File.open(INITD_PATH, 'w') do |f|
+				f << ERB.new(File.read(template)).result(binding)
+			  end
+			  sh "chmod +x #{INITD_PATH}" # Make executable
+			end
+		end
+
+		# Create the config file directory
         sh "mkdir -p #{config_files_path}"
 
+		# Let the user know how to make service persistant
         log ''
         log "To configure thin to start at system boot:"
-        log "on RedHat like systems:"
-        log "  sudo /sbin/chkconfig --level 345 #{NAME} on"
-        log "on Debian-like systems (Ubuntu):"
-        log "  sudo /usr/sbin/update-rc.d -f #{NAME} defaults"
-        log "on Gentoo:"
-        log "  sudo rc-update add #{NAME} default"
+        if SYSTEMD
+			log "  sudo systemctl enable thin"
+        else
+			log "on RedHat like systems:"
+			log "  sudo /sbin/chkconfig --level 345 #{NAME} on"
+			log "on Debian-like systems (Ubuntu):"
+			log "  sudo /usr/sbin/update-rc.d -f #{NAME} defaults"
+			log "on Gentoo:"
+			log "  sudo rc-update add #{NAME} default"
+        end
         log ''
         log "Then put your config files in #{config_files_path}"
       end
-    
+
       private
         def run(command)
           Dir[config_path + '/*'].each do |config|
@@ -65,7 +85,7 @@ module Thin
             Command.run(command, :config => config, :daemonize => true)
           end
         end
-      
+
         def sh(cmd)
           log cmd
           system(cmd)

--- a/lib/thin/controllers/thin.service.erb
+++ b/lib/thin/controllers/thin.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=A fast and very simple Ruby web server
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=<%= Command.script %> start --all <%= config_files_path %>
+ExecReload=<%= Command.script %> restart --all <%= config_files_path %>
+ExecStop=<%= Command.script %> stop --all <%= config_files_path %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As discussed on google groups, many modern linux systems have migrated from old SystemVinit to SystemD, which makes our install script outdated

This is the commit that autodetects which one of them is in use and make the change appropriately.

p.s.: I have tried to conform to the existing coding style.
