### PR TITLE
ext/thin_parser: set LC_CTYPE to C

### DIFF
--- a/ext/thin_parser/thin.c
+++ b/ext/thin_parser/thin.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "parser.h"
 #include <ctype.h>
+#include <locale.h>
 
 static VALUE mThin;
 static VALUE cHttpParser;
@@ -70,7 +71,6 @@ DEF_MAX_LENGTH(FRAGMENT, 1024); /* Don't know if this length is specified somewh
 DEF_MAX_LENGTH(REQUEST_PATH, 1024);
 DEF_MAX_LENGTH(QUERY_STRING, (1024 * 10));
 DEF_MAX_LENGTH(HEADER, (1024 * (80 + 32)));
-
 
 static void http_field(void *data, const char *field, size_t flen, const char *value, size_t vlen)
 {
@@ -395,6 +395,7 @@ void Init_thin_parser()
 {
 
   mThin = rb_define_module("Thin");
+  setlocale(LC_CTYPE, "C");
 
   DEF_GLOBAL(empty, "");
   DEF_GLOBAL(http_prefix, "HTTP_");


### PR DESCRIPTION
thin fails in unexpected ways when Accept-Language is equal to 'tr' due
to the fact that (e.g.) Turkish locale affects functions like
toupper()/tolower().

Problem lies in the fact that Turkish has different case mappings for
letters "I" and "i". A detailed explanation of the "problem" can be
found at: http://www.i18nguy.com/unicode/turkish-i18n.html

This commit sets LC_CTYPE locale to "C" which is used by functions like
toupper() and tolower().
