### PR TITLE
(Fixes #69) Remove --ssl-verify and provide peer_cert

### DIFF
--- a/lib/thin/connection.rb
+++ b/lib/thin/connection.rb
@@ -56,6 +56,12 @@ module Thin
       end
     end
 
+    def ssl_verify_peer(cert)
+      # In order to make the cert available later we have to have made at least
+      # a show of verifying it.
+      true
+    end
+
     def pre_process
       # Add client info to the request env
       @request.remote_address = remote_address

--- a/lib/thin/controllers/controller.rb
+++ b/lib/thin/controllers/controller.rb
@@ -55,7 +55,7 @@ module Thin
         # ssl support
         if @options[:ssl]
           server.ssl = true
-          server.ssl_options = { :private_key_file => @options[:ssl_key_file], :cert_chain_file => @options[:ssl_cert_file], :verify_peer => @options[:ssl_verify] }
+          server.ssl_options = { :private_key_file => @options[:ssl_key_file], :cert_chain_file => @options[:ssl_cert_file], :verify_peer => true }
         end
 
         # Detach the process, after this line the current process returns

--- a/lib/thin/runner.rb
+++ b/lib/thin/runner.rb
@@ -79,7 +79,6 @@ module Thin
         opts.on(      "--ssl", "Enables SSL")                                           { @options[:ssl] = true }
         opts.on(      "--ssl-key-file PATH", "Path to private key")                     { |path| @options[:ssl_key_file] = path }
         opts.on(      "--ssl-cert-file PATH", "Path to certificate")                    { |path| @options[:ssl_cert_file] = path }
-        opts.on(      "--ssl-verify", "Enables SSL certificate verification")           { @options[:ssl_verify] = true }
 
         opts.separator ""
         opts.separator "Adapter options:"


### PR DESCRIPTION
The get_peer_cert method of EM doesn't return anything unless the cert
has been verified. The --ssl-verify option of thin actually doesn't do
anything. These two behaviors combined mean that
env['rack.peer_cert'], which was introduced in thin 1.2.8, always
returns nil. Since --ssl-verify never actually caused a verification to
happen, it is better to remove that option until a fully verification
process is put in place. However, the peer_cert can be made available in
--ssl mode by always "verifying" the cert, thereby providing the client
supplied certificate, if there is one, available in
env['rack.peer_cert'].
