### PR TITLE
Remove version number from HTTP "Server" header.

### DIFF
--- a/lib/thin/response.rb
+++ b/lib/thin/response.rb
@@ -35,7 +35,7 @@ module Thin
     def headers_output
       # Set default headers
       @headers[CONNECTION] = persistent? ? KEEP_ALIVE : CLOSE unless @headers.has_key?(CONNECTION)
-      @headers[SERVER]     = Thin::SERVER unless @headers.has_key?(SERVER)
+      @headers[SERVER]     = Thin::NAME unless @headers.has_key?(SERVER)
 
       @headers.to_s
     end


### PR DESCRIPTION
To pass most UK government penetration tests, the web / application
server should not expose version details, or ideally product details.
This change avoids defaulting the Server header in production mode if
none has been set by the application.
