### PR TITLE
ignore emacs backup files in config_path

### DIFF
--- a/lib/thin/controllers/service.rb
+++ b/lib/thin/controllers/service.rb
@@ -61,6 +61,7 @@ module Thin
       private
         def run(command)
           Dir[config_path + '/*'].each do |config|
+            next if config.end_with?("~")
             log_info "[#{command}] #{config} ..."
             Command.run(command, :config => config, :daemonize => true)
           end


### PR DESCRIPTION
Emacs creates backup files by default whenever you change a file. These files end with a "~" e.g. "config.yml~". Thin does not ignore them but it should.

If i have a config.yml and edit it to change the number of servers i end up with a config.yml and a config.yml~ which are both used by thin.