### PR TITLE
Fix for issue 248

### DIFF
--- a/lib/thin/logging.rb
+++ b/lib/thin/logging.rb
@@ -152,7 +152,10 @@ module Thin
 
     # Log a message at ERROR level (and maybe a backtrace)
     def log_error(msg, e=nil)
-      log_msg = msg + ": #{e}\n\t" + e.backtrace.join("\n\t") + "\n" if e
+      log_msg = msg
+      if e
+        log_msg += ": #{e}\n\t" + e.backtrace.join("\n\t") + "\n"
+      end
       Logging.log_msg(log_msg, Logger::ERROR)
     end
     module_function :log_error


### PR DESCRIPTION
If an exception object is not passed to `log_error`, ensure that `log_msg` is built anyway. Otherwise, there is no way to log at `Logger::ERROR` level.

Resolves #248