### PR TITLE
Update eventmachine for ruby 2.2.0

### DIFF
--- a/thin.gemspec
+++ b/thin.gemspec
@@ -20,7 +20,7 @@ Thin::GemSpec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.5'
   
   s.add_dependency        'rack',         '~> 1.0'
-  s.add_dependency        'eventmachine', '~> 1.0'
+  s.add_dependency        'eventmachine', '~> 1.0.4'
   s.add_dependency        'daemons',      '~> 1.0', '>= 1.0.9'  unless Thin.win?
 
   s.files                 = %w(CHANGELOG README.md Rakefile) +


### PR DESCRIPTION
Thin depends on eventmachine which fails to build on `ruby >= 2.2` prior to `1.0.4`, [related issue][1].
This PR updates eventmachine dependency to `~> 1.0.4`


[1]: https://github.com/eventmachine/eventmachine/issues/553