### PR TITLE
When restarting, exit on a next tick so we can send response back to a client

### DIFF
--- a/lib/thin/daemonizing.rb
+++ b/lib/thin/daemonizing.rb
@@ -95,7 +95,7 @@ module Thin
         stop
         remove_pid_file
         @on_restart.call
-        exit!
+        EM.next_tick { exit! }
       end
     end
     


### PR DESCRIPTION
Hi,

I've noticed, that if I restart thin while it handles a connection, it doesn't send response back.

Example app:
```
require 'thin'

app = proc do |env|
  body = ["hi!"]
  sleep 10
  [200, { 'Content-Type' => 'text/html' }, body]
end

run app
```
Then if I do ```thin -d start```, then ```curl localhost:3000``` and then immediately ```thin -d restart```, thin will wait 10 seconds while the work is in progress and then will go to restart. But no response will be sent back:
```
$ curl localhost:3000
curl: (52) Empty reply from server
```

I am not sure this is the right approach, but if I call ```exit!``` in the next tick, all works correctly.
```
$ curl localhost:3000
hi!
```