### PR TITLE
add :timeout option for Rack::Server.new

### DIFF
--- a/lib/thin/server.rb
+++ b/lib/thin/server.rb
@@ -125,7 +125,7 @@ module Thin
       # Set defaults
       @backend.maximum_connections            = DEFAULT_MAXIMUM_CONNECTIONS
       @backend.maximum_persistent_connections = DEFAULT_MAXIMUM_PERSISTENT_CONNECTIONS
-      @backend.timeout                        = DEFAULT_TIMEOUT
+      @backend.timeout                        = options[:timeout] || DEFAULT_TIMEOUT
       
       # Allow using Rack builder as a block
       @app = Rack::Builder.new(&block).to_app if block


### PR DESCRIPTION
When I try calling it via `Rack::Server.new(server: "thin")`, there seems to be no way to specify request timeout.
This change will let us use `timeout` option on `Rack::Server.new`. The usage is like below:

```
Rack::Server.new(server: "thin", timeout: 180).start
```
