### PR TITLE
initialize `@trace_logger` to nil

### DIFF
--- a/lib/thin/logging.rb
+++ b/lib/thin/logging.rb
@@ -17,6 +17,8 @@ module Thin
       end
     end
 
+    @trace_logger = nil
+
     class << self
       attr_reader :logger
       attr_reader :trace_logger


### PR DESCRIPTION
`trace_message` is issuing many warnings in the Rack tests.  Initializing `@trace_logger` to nil eliminates those warnings.