### PR TITLE
Mac OS X / BSD Kqueue Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+ * Don't try to enable epoll on unsupported platform [felixbuenemann]
+ * Add kqueue support for BSD/Darwin, disable with `--no-kqueue` [felixbuenemann]
 == 1.6.3 Protein Powder
  * Add HTTP 422 status code [rajcybage]
  * Add warning about EM reactor still running when stopping.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ environment: production
 max_persistent_conns: 512
 servers: 1
 threaded: true
-no-epoll: true
 daemonize: true
 socket: tmp/sockets/thin.sock
 chdir: /path/to/your/apps/root
@@ -140,9 +139,10 @@ Tuning options:
         --max-persistent-conns NUM   Maximum number of persistent connections
                                      (default: 100)
         --threaded                   Call the Rack application in threads [experimental]
-        --threadpool-size NUM        Sets the size of the EventMachine threadpool.
+        --threadpool-size NUM        Sets the size of the EventMachine threadpool
                                      (default: 20)
         --no-epoll                   Disable the use of epoll
+        --no-kqueue                  Disable the use of kqueue
 
 Common options:
     -r, --require FILE               require the library

--- a/example/async_chat.ru
+++ b/example/async_chat.ru
@@ -6,10 +6,6 @@
 #  Created by James Tucker on 2008-06-19.
 #  Copyright 2008 James Tucker <raggi@rubyforge.org>.
 
-# Uncomment if appropriate for you..
-EM.epoll
-# EM.kqueue # bug on OS X in 0.12?
-
 class DeferrableBody
   include EventMachine::Deferrable
   

--- a/example/async_tailer.ru
+++ b/example/async_tailer.ru
@@ -8,10 +8,6 @@
 #  Created by James Tucker on 2008-06-18.
 #  Copyright 2008 James Tucker <raggi@rubyforge.org>.
 
-# Uncomment if appropriate for you..
-# EM.epoll
-# EM.kqueue
-
 class DeferrableBody
   include EventMachine::Deferrable
   

--- a/lib/thin/controllers/controller.rb
+++ b/lib/thin/controllers/controller.rb
@@ -49,7 +49,8 @@ module Thin
         server.maximum_connections            = @options[:max_conns]
         server.maximum_persistent_connections = @options[:max_persistent_conns]
         server.threaded                       = @options[:threaded]
-        server.no_epoll                       = @options[:no_epoll] if server.backend.respond_to?(:no_epoll=)
+        server.no_epoll                       = @options[:no_epoll]  if server.backend.respond_to?(:no_epoll=)
+        server.no_kqueue                      = @options[:no_kqueue] if server.backend.respond_to?(:no_kqueue=)
         server.threadpool_size                = @options[:threadpool_size] if server.threaded?
 
         # ssl support

--- a/lib/thin/runner.rb
+++ b/lib/thin/runner.rb
@@ -126,9 +126,10 @@ module Thin
                                        "(default: #{@options[:max_persistent_conns]})") { |num| @options[:max_persistent_conns] = num.to_i }
         opts.on(      "--threaded", "Call the Rack application in threads " +
                                     "[experimental]")                                   { @options[:threaded] = true }
-        opts.on(      "--threadpool-size NUM", "Sets the size of the EventMachine threadpool.",
+        opts.on(      "--threadpool-size NUM", "Sets the size of the EventMachine threadpool",
                                        "(default: #{@options[:threadpool_size]})") { |num| @options[:threadpool_size] = num.to_i }
-        opts.on(      "--no-epoll", "Disable the use of epoll")                         { @options[:no_epoll] = true } if Thin.linux?
+        opts.on(      "--no-epoll", "Disable the use of epoll")                         { @options[:no_epoll] = true } if EventMachine.epoll?
+        opts.on(      "--no-kqueue", "Disable the use of kqueue")                       { @options[:no_kqueue] = true } if EventMachine.kqueue?
 
         opts.separator ""
         opts.separator "Common options:"

--- a/lib/thin/server.rb
+++ b/lib/thin/server.rb
@@ -96,6 +96,9 @@ module Thin
     
     # Disable the use of epoll under Linux
     def_delegators :backend, :no_epoll, :no_epoll=
+
+    # Disable the use of kqueue under BSD / Darwin
+    def_delegators :backend, :no_kqueue, :no_kqueue=
     
     def initialize(*args, &block)
       host, port, options = DEFAULT_HOST, DEFAULT_PORT, {}

--- a/spec/backends/tcp_server_spec.rb
+++ b/spec/backends/tcp_server_spec.rb
@@ -5,14 +5,33 @@ describe Backends::TcpServer do
     @backend = Backends::TcpServer.new('0.0.0.0', 3333)
   end
   
-  it "should not use epoll" do
+  it "should not use epoll if disabled" do
     @backend.no_epoll = true
     EventMachine.should_not_receive(:epoll)
     @backend.config
   end
   
-  it "should use epoll" do
-    EventMachine.should_receive(:epoll)
+  it "should use epoll if supported" do
+    if EventMachine.epoll?
+      EventMachine.should_receive(:epoll)
+    else
+      EventMachine.should_not_receive(:epoll)
+    end
+    @backend.config
+  end
+
+  it "should not use kqueue if disabled" do
+    @backend.no_kqueue = true
+    EventMachine.should_not_receive(:kqueue)
+    @backend.config
+  end
+
+  it "should use kqueue if supported" do
+    if EventMachine.kqueue?
+      EventMachine.should_receive(:kqueue)
+    else
+      EventMachine.should_not_receive(:kqueue)
+    end
     @backend.config
   end
   

--- a/spec/server/robustness_spec.rb
+++ b/spec/server/robustness_spec.rb
@@ -16,15 +16,15 @@ describe Server, 'robustness' do
         socket.write("Host: localhost\r\n")
         socket.write("Connection: close\r\n")
         10000.times do
-        	socket.write("X-Foo: #{'x' * 100}\r\n")
-        	socket.flush
+          socket.write("X-Foo: #{'x' * 100}\r\n")
+          socket.flush
         end
         socket.write("\r\n")
         socket.read
         socket.close
-      rescue Errno::EPIPE, Errno::ECONNRESET
-				# Ignore.
-			end
+      rescue Errno::EPIPE, Errno::ECONNRESET, Errno::EPROTOTYPE
+        # Ignore.
+      end
     end
   end
   


### PR DESCRIPTION
- Fix failing robustness spec on Mac OS X (missing an extra allowed exception)
- Don't try to enable epoll on unsupported platform
- Auto-enable kqueue on supported platforms
- Add `--no-kqueue` option to disable kqueue
- Remove unneeded manual calls to EM.epoll/kqueue from examples
- Remove `no-epoll` from config example in README to protect users from accidentally disabling epoll
- Update specs and changelog
- Remove period from threadpool option help for consistency [cosmetic]
