### PR TITLE
Allow Rack versions higher than 1.0

### DIFF
--- a/thin.gemspec
+++ b/thin.gemspec
@@ -19,7 +19,7 @@ Thin::GemSpec = Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.8.5'
   
-  s.add_dependency        'rack',         '~> 1.0'
+  s.add_dependency        'rack',         '>= 1.0'
   s.add_dependency        'eventmachine', '~> 1.0.4'
   s.add_dependency        'daemons',      '~> 1.0', '>= 1.0.9'  unless Thin.win?
 


### PR DESCRIPTION
At Basecamp we're developing along with Rails 5. I'm trying to keep it up-to-date with master but the Rack requirement on thin is currently too stringent for that since Rails 5 (Rails master) now requires Rack 2 (Rack master).  :smile: Thanks for your work on thin! 

---
Although unreleased Rack master is now Rack 2.0. Rails 5 is in
development and requiring Rack 2.0 so any project using Rails master and
thin currently can't work together.

This loosens the Rack requirement so Rails apps using Rails master can
still use thin.