### PR TITLE
Set $USER and $HOME when running as another user

### DIFF
--- a/lib/thin/daemonizing.rb
+++ b/lib/thin/daemonizing.rb
@@ -78,6 +78,10 @@ module Thin
         Process.initgroups(user, target_gid)
         Process::GID.change_privilege(target_gid)
         Process::UID.change_privilege(target_uid)
+
+        # Correct environment variables
+        ENV.store('USER', user)
+        ENV.store('HOME', File.expand_path("~#{user}"))
       end
     rescue Errno::EPERM => e
       log_info "Couldn't change user and group to #{user}:#{group}: #{e}"


### PR DESCRIPTION
When running Thin as another user, $USER and $HOME are set using the same parameters as when setting the UID and GID.

Resolves #275 
