### PR TITLE
TCP/IP Backend reports incorrect port when asked to bind to 0

### DIFF
--- a/lib/thin/backends/tcp_server.rb
+++ b/lib/thin/backends/tcp_server.rb
@@ -4,23 +4,28 @@ module Thin
     class TcpServer < Base
       # Address and port on which the server is listening for connections.
       attr_accessor :host, :port
-      
+
       def initialize(host, port)
         @host = host
         @port = port
         super()
       end
-      
+
       # Connect the server
       def connect
         @signature = EventMachine.start_server(@host, @port, Connection, &method(:initialize_connection))
+        binary_name = EventMachine.get_sockname( @signature )
+        port_name = Socket.unpack_sockaddr_in( binary_name )
+        @port = port_name[0]
+        @host = port_name[1]
+        @signature
       end
-      
+
       # Stops the server
       def disconnect
         EventMachine.stop_server(@signature)
       end
-            
+
       def to_s
         "#{@host}:#{@port}"
       end


### PR DESCRIPTION
This PR updates the TCP/IP backend to report the anonymous port and the address the actual service socket was bound to.