### PR TITLE
Don't need "int cs" variable here

### DIFF
--- a/ext/thin_parser/parser.c
+++ b/ext/thin_parser/parser.c
@@ -1437,11 +1437,6 @@ int thin_http_parser_is_finished(http_parser *parser) {
 
 int thin_http_parser_finish(http_parser *parser)
 {
-  int cs = parser->cs;
-
-
-  parser->cs = cs;
-
   if (thin_http_parser_has_error(parser) ) {
     return -1;
   } else if (thin_http_parser_is_finished(parser) ) {

--- a/ext/thin_parser/parser.rl
+++ b/ext/thin_parser/parser.rl
@@ -142,11 +142,6 @@ int thin_http_parser_is_finished(http_parser *parser) {
 
 int thin_http_parser_finish(http_parser *parser)
 {
-  int cs = parser->cs;
-
-
-  parser->cs = cs;
-
   if (thin_http_parser_has_error(parser) ) {
     return -1;
   } else if (thin_http_parser_is_finished(parser) ) {


### PR DESCRIPTION
Hello there,

i have had a code-reading session, during which i've noticed that "cs" variable became orphan after [this commit](https://github.com/macournoyer/thin/commit/d5b523e6fda527588c690b5f37c25893c1cd0701#diff-c93c578d3adba198316570e4199fb804L140)

sorry in advance if i'm wrong.