### PR TITLE
Add support for grouping cluster restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Cluster options:
     -C, --config FILE                Load options from config file
         --all [DIR]                  Send command to each config files in DIR
     -O, --onebyone                   Restart the cluster one by one (only works with restart command)
+    -X, --xbyx                       Restart the cluster in batches up to X servers at a time (only works with restart command)
     -w, --wait NUM                   Maximum wait time for server to be started in seconds (use with -O)
 
 Tuning options:

--- a/lib/thin/runner.rb
+++ b/lib/thin/runner.rb
@@ -108,6 +108,7 @@ module Thin
           opts.on("-C", "--config FILE", "Load options from config file")               { |file| @options[:config] = file }
           opts.on(      "--all [DIR]", "Send command to each config files in DIR")      { |dir| @options[:all] = dir } if Thin.linux?
           opts.on("-O", "--onebyone", "Restart the cluster one by one (only works with restart command)") { @options[:onebyone] = true }
+          opts.on("-X", "--xbyx NUM", "Restart the cluster in batches up to X servers at a time (only works with restart command)") { |num| @options[:xbyx] = num.to_i }
           opts.on("-w", "--wait NUM", "Maximum wait time for server to be started in seconds (use with -O)") { |time| @options[:wait] = time.to_i }
         end
 

--- a/lib/thin/version.rb
+++ b/lib/thin/version.rb
@@ -6,7 +6,7 @@ module Thin
   module VERSION #:nodoc:
     MAJOR    = 1
     MINOR    = 6
-    TINY     = 4
+    TINY     = 5
     
     STRING   = [MAJOR, MINOR, TINY].join('.')
     


### PR DESCRIPTION
The cluster restart one by one or all at once options are handy but I found a need to group clusters into batches for restarting. Let me know if you need me to adjust anything in the PR. Hope its helpful