### PR TITLE
Fix test suite for the case /etc/rc.d exists.

### DIFF
--- a/spec/controllers/service_spec.rb
+++ b/spec/controllers/service_spec.rb
@@ -27,8 +27,10 @@ describe Service do
     @service.install
     
     File.exist?(Service::INITD_PATH).should be_true
+    script_name = File.directory?('/etc/rc.d') ?
+      '/etc/rc.d/thin' : '/etc/init.d/thin'
     File.read(Service::INITD_PATH).should include('CONFIG_PATH=tmp/sandbox/etc/thin',
-                                                  'SCRIPT_NAME=tmp/sandbox/etc/init.d/thin',
+                                                  'SCRIPT_NAME=tmp/sandbox' + script_name,
                                                   'DAEMON=' + Command.script)
   end
   


### PR DESCRIPTION
Hi,
I am using Fedora 23.
And I got test failure in my environment.
Then I modified the test case a little bit to pass the test suite.

```
$ ruby -v
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]

$ bundle install --path vendor/bundle

$ bundle exec rake spec
...
1)
'Thin::Controllers::Service should create /etc/init.d/thin file when calling install' FAILED
expected "#!/bin/sh\n### BEGIN INIT INFO\n# Provides:          thin\n# Required-Start:    $local_fs $remote_fs\n# Required-Stop:     $local_fs $remote_fs\n# Default-Start:     2 3 4 5\n# Default-Stop:      S 0 1 6\n# Short-Description: thin initscript\n# Description:       thin\n### END INIT INFO\n\n# Original author: Forrest Robertson\n\n# Do NOT \"set -e\"\n\nDAEMON=thin\nSCRIPT_NAME=tmp/sandbox/etc/rc.d/thin\nCONFIG_PATH=tmp/sandbox/etc/thin\n\n# Exit if the package is not installed\n[ -x \"$DAEMON\" ] || exit 0\n\ncase \"$1\" in\n  start)\n\t$DAEMON start --all $CONFIG_PATH\n\t;;\n  stop)\n\t$DAEMON stop --all $CONFIG_PATH\n\t;;\n  restart)\n\t$DAEMON restart --all $CONFIG_PATH\n\t;;\n  *)\n\techo \"Usage: $SCRIPT_NAME {start|stop|restart}\" >&2\n\texit 3\n\t;;\nesac\n\n:\n" to include "CONFIG_PATH=tmp/sandbox/etc/thin", "SCRIPT_NAME=tmp/sandbox/etc/init.d/thin", and "DAEMON=thin"
```

The reason of this failure is because my environment has /etc/rc.d directory.

```
$ ls /etc/rc.d/
init.d/  rc0.d/  rc1.d/  rc2.d/  rc3.d/  rc4.d/  rc5.d/  rc6.d/
```

And INITD_PATH depends on its situation.
https://github.com/macournoyer/thin/blob/627397b8fd38a6ace1d9e1c9a08ac3cbaac3f1dd/lib/thin/controllers/service.rb#L8

Could you merge this modification to your master branch?

I think that after you will merge this modification, you can close below issue too.
https://github.com/macournoyer/thin/issues/76

Thanks.