### PR TITLE
For clusters, allow --wait to be passed down

### DIFF
--- a/lib/thin/controllers/cluster.rb
+++ b/lib/thin/controllers/cluster.rb
@@ -3,7 +3,7 @@ require 'socket'
 module Thin
   # An exception class to handle the event that server didn't start on time
   class RestartTimeout < RuntimeError; end
-  
+
   module Controllers
     # Control a set of servers.
     # * Generate start and stop commands and run them.
@@ -12,18 +12,18 @@ module Thin
     class Cluster < Controller
       # Cluster only options that should not be passed in the command sent
       # to the indiviual servers.
-      CLUSTER_OPTIONS = [:servers, :only, :onebyone, :wait]
-      
+      CLUSTER_OPTIONS = [:servers, :only, :onebyone]
+
       # Maximum wait time for the server to be restarted
       DEFAULT_WAIT_TIME = 30    # seconds
-      
+
       # Create a new cluster of servers launched using +options+.
       def initialize(options)
         super
         # Cluster can only contain daemonized servers
         @options.merge!(:daemonize => true)
       end
-      
+
       def first_port; @options[:port]     end
       def address;    @options[:address]  end
       def socket;     @options[:socket]   end
@@ -33,35 +33,35 @@ module Thin
       def only;       @options[:only]     end
       def onebyone;   @options[:onebyone] end
       def wait;       @options[:wait]     end
-      
+
       def swiftiply?
         @options.has_key?(:swiftiply)
       end
-    
+
       # Start the servers
       def start
         with_each_server { |n| start_server n }
       end
-    
+
       # Start a single server
       def start_server(number)
         log_info "Starting server on #{server_id(number)} ... "
-      
+
         run :start, number
       end
-  
+
       # Stop the servers
       def stop
         with_each_server { |n| stop_server n }
       end
-    
+
       # Stop a single server
       def stop_server(number)
         log_info "Stopping server on #{server_id(number)} ... "
-      
+
         run :stop, number
       end
-    
+
       # Stop and start the servers.
       def restart
         unless onebyone
@@ -70,7 +70,7 @@ module Thin
           sleep 0.1 # Let's breath a bit shall we ?
           start
         else
-          with_each_server do |n| 
+          with_each_server do |n|
             stop_server(n)
             sleep 0.1 # Let's breath a bit shall we ?
             start_server(n)
@@ -78,7 +78,7 @@ module Thin
           end
         end
       end
-      
+
       def test_socket(number)
         if socket
           UNIXSocket.new(socket_for(number))
@@ -88,12 +88,12 @@ module Thin
       rescue
         nil
       end
-      
+
       # Make sure the server is running before moving on to the next one.
       def wait_until_server_started(number)
         log_info "Waiting for server to start ..."
         STDOUT.flush # Need this to make sure user got the message
-        
+
         tries = 0
         loop do
           if test_socket = test_socket(number)
@@ -109,7 +109,7 @@ module Thin
           end
         end
       end
-    
+
       def server_id(number)
         if socket
           socket_for(number)
@@ -119,23 +119,23 @@ module Thin
           [address, number].join(':')
         end
       end
-    
+
       def log_file_for(number)
         include_server_number log_file, number
       end
-    
+
       def pid_file_for(number)
         include_server_number pid_file, number
       end
-    
+
       def socket_for(number)
         include_server_number socket, number
       end
-    
+
       def pid_for(number)
         File.read(pid_file_for(number)).chomp.to_i
       end
-      
+
       private
         # Send the command to the +thin+ script
         def run(cmd, number)
@@ -150,7 +150,7 @@ module Thin
           end
           Command.run(cmd, cmd_options)
         end
-      
+
         def with_each_server
           if only
             if first_port && only < 80
@@ -166,7 +166,7 @@ module Thin
             size.times { |n| yield first_port + n }
           end
         end
-      
+
         # Add the server port or number in the filename
         # so each instance get its own file
         def include_server_number(path, number)

--- a/lib/thin/controllers/controller.rb
+++ b/lib/thin/controllers/controller.rb
@@ -3,37 +3,37 @@ require 'yaml'
 module Thin
   # Error raised that will abort the process and print not backtrace.
   class RunnerError < RuntimeError; end
-  
+
   # Raised when a mandatory option is missing to run a command.
   class OptionRequired < RunnerError
     def initialize(option)
       super("#{option} option required")
     end
   end
-  
+
   # Raised when an option is not valid.
   class InvalidOption < RunnerError; end
-  
+
   # Build and control Thin servers.
   # Hey Controller pattern is not only for web apps yo!
-  module Controllers  
+  module Controllers
     # Controls one Thin server.
     # Allow to start, stop, restart and configure a single thin server.
     class Controller
       include Logging
-    
+
       # Command line options passed to the thin script
       attr_accessor :options
-    
+
       def initialize(options)
         @options = options
-        
+
         if @options[:socket]
           @options.delete(:address)
           @options.delete(:port)
         end
       end
-    
+
       def start
         # Constantize backend class
         @options[:backend] = eval(@options[:backend], TOPLEVEL_BINDING) if @options[:backend]
@@ -41,7 +41,7 @@ module Thin
         server = Server.new(@options[:socket] || @options[:address], # Server detects kind of socket
                             @options[:port],                         # Port ignored on UNIX socket
                             @options)
-        
+
         # Set options
         server.pid_file                       = @options[:pid]
         server.log_file                       = @options[:log]
@@ -63,7 +63,7 @@ module Thin
 
         # +config+ must be called before changing privileges since it might require superuser power.
         server.config
-        
+
         server.change_privilege @options[:user], @options[:group] if @options[:user] && @options[:group]
 
         # If a Rack config file is specified we eval it inside a Rack::Builder block to create
@@ -86,27 +86,27 @@ module Thin
 
         server.start
       end
-    
+
       def stop
         raise OptionRequired, :pid unless @options[:pid]
-      
+
         tail_log(@options[:log]) do
-          if Server.kill(@options[:pid], @options[:force] ? 0 : (@options[:timeout] || 60))
+          if Server.kill(@options[:pid], @options[:force] ? 0 : (@options[:wait] || 60))
             wait_for_file :deletion, @options[:pid]
           end
         end
       end
-    
+
       def restart
         raise OptionRequired, :pid unless @options[:pid]
-        
+
         tail_log(@options[:log]) do
           if Server.restart(@options[:pid])
             wait_for_file :creation, @options[:pid]
           end
         end
       end
-    
+
       def config
         config_file = @options.delete(:config) || raise(OptionRequired, :config)
 
@@ -116,19 +116,19 @@ module Thin
         File.open(config_file, 'w') { |f| f << @options.to_yaml }
         log_info "Wrote configuration to #{config_file}"
       end
-      
+
       protected
         # Wait for a pid file to either be created or deleted.
         def wait_for_file(state, file)
-          Timeout.timeout(@options[:timeout] || 30) do
+          Timeout.timeout(@options[:wait] || 30) do
             case state
             when :creation then sleep 0.1 until File.exist?(file)
             when :deletion then sleep 0.1 while File.exist?(file)
             end
           end
         end
-        
-        # Tail the log file of server +number+ during the execution of the block.        
+
+        # Tail the log file of server +number+ during the execution of the block.
         def tail_log(log_file)
           if log_file
             tail_thread = tail(log_file)
@@ -138,7 +138,7 @@ module Thin
             yield
           end
         end
-        
+
         # Acts like GNU tail command. Taken from Rails.
         def tail(file)
           cursor = File.exist?(file) ? File.size(file) : 0
@@ -171,7 +171,7 @@ module Thin
         rescue Rack::AdapterNotFound => e
           raise InvalidOption, e.message
         end
-        
+
         def load_rackup_config
           ENV['RACK_ENV'] = @options[:environment]
           case @options[:rackup]

--- a/spec/controllers/cluster_spec.rb
+++ b/spec/controllers/cluster_spec.rb
@@ -5,19 +5,19 @@ describe Cluster, "with host and port" do
   before do
     @cluster = Cluster.new(:chdir => '/rails_app',
                            :address => '0.0.0.0',
-                           :port => 3000, 
+                           :port => 3000,
                            :servers => 3,
                            :timeout => 10,
                            :log => 'thin.log',
                            :pid => 'thin.pid'
                           )
   end
-    
+
   it 'should include port number in file names' do
     @cluster.send(:include_server_number, 'thin.log', 3000).should == 'thin.3000.log'
     @cluster.send(:include_server_number, 'thin.pid', 3000).should == 'thin.3000.pid'
   end
-  
+
   it 'should call each server' do
     calls = []
     @cluster.send(:with_each_server) do |port|
@@ -25,7 +25,7 @@ describe Cluster, "with host and port" do
     end
     calls.should == [3000, 3001, 3002]
   end
-    
+
   it 'should start on each port' do
     Command.should_receive(:run).with(:start, options_for_port(3000))
     Command.should_receive(:run).with(:start, options_for_port(3001))
@@ -41,7 +41,7 @@ describe Cluster, "with host and port" do
 
     @cluster.stop
   end
-  
+
   private
     def options_for_port(port)
       { :daemonize => true, :log => "thin.#{port}.log", :timeout => 10, :address => "0.0.0.0", :port => port, :pid => "thin.#{port}.pid", :chdir => "/rails_app" }
@@ -60,17 +60,17 @@ describe Cluster, "with UNIX socket" do
                            :pid => 'thin.pid'
                           )
   end
-  
+
   it 'should include socket number in file names' do
     @cluster.send(:include_server_number, 'thin.sock', 0).should == 'thin.0.sock'
     @cluster.send(:include_server_number, 'thin', 0).should == 'thin.0'
   end
-  
+
   it "should exclude :address and :port options" do
     @cluster.options.should_not have_key(:address)
     @cluster.options.should_not have_key(:port)
   end
-  
+
   it 'should call each server' do
     calls = []
     @cluster.send(:with_each_server) do |n|
@@ -78,7 +78,7 @@ describe Cluster, "with UNIX socket" do
     end
     calls.should == [0, 1, 2]
   end
-  
+
   it 'should start each server' do
     Command.should_receive(:run).with(:start, options_for_socket(0))
     Command.should_receive(:run).with(:start, options_for_socket(1))
@@ -94,8 +94,8 @@ describe Cluster, "with UNIX socket" do
 
     @cluster.stop
   end
-  
-  
+
+
   private
     def options_for_socket(number)
       { :daemonize => true, :log => "thin.#{number}.log", :timeout => 10, :socket => "/tmp/thin.#{number}.sock", :pid => "thin.#{number}.pid", :chdir => "/rails_app" }
@@ -106,7 +106,7 @@ describe Cluster, "controlling only one server" do
   before do
     @cluster = Cluster.new(:chdir => '/rails_app',
                            :address => '0.0.0.0',
-                           :port => 3000, 
+                           :port => 3000,
                            :servers => 3,
                            :timeout => 10,
                            :log => 'thin.log',
@@ -114,7 +114,7 @@ describe Cluster, "controlling only one server" do
                            :only => 3001
                           )
   end
-  
+
   it 'should call only specified server' do
     calls = []
     @cluster.send(:with_each_server) do |n|
@@ -122,13 +122,13 @@ describe Cluster, "controlling only one server" do
     end
     calls.should == [3001]
   end
-  
+
   it "should start only specified server" do
     Command.should_receive(:run).with(:start, options_for_port(3001))
 
     @cluster.start
   end
-  
+
   private
     def options_for_port(port)
       { :daemonize => true, :log => "thin.#{port}.log", :timeout => 10, :address => "0.0.0.0", :port => port, :pid => "thin.#{port}.pid", :chdir => "/rails_app" }
@@ -148,7 +148,7 @@ describe Cluster, "controlling only one server with UNIX socket" do
                            :only => 1
                           )
   end
-  
+
   it 'should call only specified server' do
     calls = []
     @cluster.send(:with_each_server) do |n|
@@ -162,7 +162,7 @@ describe Cluster, "controlling only one server, by sequence number" do
   before do
     @cluster = Cluster.new(:chdir => '/rails_app',
                            :address => '0.0.0.0',
-                           :port => 3000, 
+                           :port => 3000,
                            :servers => 3,
                            :timeout => 10,
                            :log => 'thin.log',
@@ -170,7 +170,7 @@ describe Cluster, "controlling only one server, by sequence number" do
                            :only => 1
                           )
   end
-  
+
   it 'should call only specified server' do
     calls = []
     @cluster.send(:with_each_server) do |n|
@@ -178,13 +178,13 @@ describe Cluster, "controlling only one server, by sequence number" do
     end
     calls.should == [3001]
   end
-  
+
   it "should start only specified server" do
     Command.should_receive(:run).with(:start, options_for_port(3001))
 
     @cluster.start
   end
-  
+
   private
     def options_for_port(port)
       { :daemonize => true, :log => "thin.#{port}.log", :timeout => 10, :address => "0.0.0.0", :port => port, :pid => "thin.#{port}.pid", :chdir => "/rails_app" }
@@ -195,7 +195,7 @@ describe Cluster, "with Swiftiply" do
   before do
     @cluster = Cluster.new(:chdir => '/rails_app',
                            :address => '0.0.0.0',
-                           :port => 3000, 
+                           :port => 3000,
                            :servers => 3,
                            :timeout => 10,
                            :log => 'thin.log',
@@ -203,7 +203,7 @@ describe Cluster, "with Swiftiply" do
                            :swiftiply => true
                           )
   end
-  
+
   it 'should call each server' do
     calls = []
     @cluster.send(:with_each_server) do |n|
@@ -211,7 +211,7 @@ describe Cluster, "with Swiftiply" do
     end
     calls.should == [0, 1, 2]
   end
-  
+
   it 'should start each server' do
     Command.should_receive(:run).with(:start, options_for_swiftiply(0))
     Command.should_receive(:run).with(:start, options_for_swiftiply(1))
@@ -227,7 +227,7 @@ describe Cluster, "with Swiftiply" do
 
     @cluster.stop
   end
-  
+
   private
     def options_for_swiftiply(number)
       { :address => '0.0.0.0', :port => 3000, :daemonize => true, :log => "thin.#{number}.log", :timeout => 10, :pid => "thin.#{number}.pid", :chdir => "/rails_app", :swiftiply => true }
@@ -238,7 +238,7 @@ describe Cluster, "rolling restart" do
   before do
     @cluster = Cluster.new(:chdir => '/rails_app',
                            :address => '0.0.0.0',
-                           :port => 3000, 
+                           :port => 3000,
                            :servers => 2,
                            :timeout => 10,
                            :log => 'thin.log',
@@ -247,21 +247,21 @@ describe Cluster, "rolling restart" do
                            :wait => 30
                           )
   end
-  
+
   it "should restart servers one by one" do
     Command.should_receive(:run).with(:stop, options_for_port(3000))
     Command.should_receive(:run).with(:start, options_for_port(3000))
     @cluster.should_receive(:wait_until_server_started).with(3000)
-    
+
     Command.should_receive(:run).with(:stop, options_for_port(3001))
     Command.should_receive(:run).with(:start, options_for_port(3001))
     @cluster.should_receive(:wait_until_server_started).with(3001)
-    
+
     @cluster.restart
   end
-  
+
   private
     def options_for_port(port)
-      { :daemonize => true, :log => "thin.#{port}.log", :timeout => 10, :address => "0.0.0.0", :port => port, :pid => "thin.#{port}.pid", :chdir => "/rails_app" }
+      { :daemonize => true, :log => "thin.#{port}.log", :timeout => 10, :address => "0.0.0.0", :port => port, :pid => "thin.#{port}.pid", :chdir => "/rails_app", :wait => 30 }
     end
 end

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -12,67 +12,67 @@ describe Controller, 'start' do
                                  :max_conns            => 2000,
                                  :max_persistent_conns => 1000,
                                  :adapter              => 'rails')
-    
+
     @server = OpenStruct.new
     @adapter = OpenStruct.new
-    
+
     Server.should_receive(:new).with('0.0.0.0', 3000, @controller.options).and_return(@server)
     @server.should_receive(:config)
     Rack::Adapter::Rails.stub!(:new).and_return(@adapter)
   end
-  
+
   it "should configure server" do
     @controller.start
-    
+
     @server.app.should == @adapter
     @server.pid_file.should == 'thin.pid'
     @server.log_file.should == 'thin.log'
     @server.maximum_connections.should == 2000
     @server.maximum_persistent_connections.should == 1000
   end
-  
+
   it "should start as daemon" do
     @controller.options[:daemonize] = true
     @controller.options[:user] = true
     @controller.options[:group] = true
-    
+
     @server.should_receive(:daemonize)
     @server.should_receive(:change_privilege)
 
     @controller.start
   end
-  
+
   it "should configure Rails adapter" do
     Rack::Adapter::Rails.should_receive(:new).with(@controller.options.merge(:root => nil))
-    
+
     @controller.start
   end
-  
+
   it "should mount app under :prefix" do
     @controller.options[:prefix] = '/app'
     @controller.start
-    
+
     @server.app.class.should == Rack::URLMap
   end
 
   it "should mount Stats adapter under :stats" do
     @controller.options[:stats] = '/stats'
     @controller.start
-    
+
     @server.app.class.should == Stats::Adapter
   end
-  
+
   it "should load app from Rack config" do
     @controller.options[:rackup] = File.dirname(__FILE__) + '/../../example/config.ru'
     @controller.start
-    
+
     @server.app.class.should == Proc
   end
 
   it "should load app from ruby file" do
     @controller.options[:rackup] = File.dirname(__FILE__) + '/../../example/myapp.rb'
     @controller.start
-    
+
     @server.app.should == Myapp
   end
 
@@ -82,40 +82,40 @@ describe Controller, 'start' do
       @controller.start
     end.should raise_error(RuntimeError, /please/)
   end
-  
+
   it "should set server as threaded" do
     @controller.options[:threaded] = true
     @controller.start
-    
+
     @server.threaded.should be_true
   end
-  
+
   it "should set RACK_ENV" do
     @controller.options[:rackup] = File.dirname(__FILE__) + '/../../example/config.ru'
     @controller.options[:environment] = "lolcat"
     @controller.start
-    
+
     ENV['RACK_ENV'].should == "lolcat"
   end
-    
+
 end
 
 describe Controller do
   before do
-    @controller = Controller.new(:pid => 'thin.pid', :timeout => 10)
+    @controller = Controller.new(:pid => 'thin.pid', :wait => 10)
     @controller.stub!(:wait_for_file)
   end
-  
+
   it "should stop" do
     Server.should_receive(:kill).with('thin.pid', 10)
     @controller.stop
   end
-  
+
   it "should restart" do
     Server.should_receive(:restart).with('thin.pid')
     @controller.restart
   end
-  
+
   it "should write configuration file" do
     silence_stream(STDOUT) do
       Controller.new(:config => 'test.yml', :port => 5000, :address => '127.0.0.1').config

--- a/spec/server/robustness_spec.rb
+++ b/spec/server/robustness_spec.rb
@@ -7,7 +7,7 @@ describe Server, 'robustness' do
       [200, { 'Content-Type' => 'text/html' }, body]
     end
   end
-  
+
   it "should not crash when header too large" do
     100.times do
       begin
@@ -16,18 +16,18 @@ describe Server, 'robustness' do
         socket.write("Host: localhost\r\n")
         socket.write("Connection: close\r\n")
         10000.times do
-        	socket.write("X-Foo: #{'x' * 100}\r\n")
-        	socket.flush
+          socket.write("X-Foo: #{'x' * 100}\r\n")
+          socket.flush
         end
         socket.write("\r\n")
         socket.read
         socket.close
       rescue Errno::EPIPE, Errno::ECONNRESET
-				# Ignore.
-			end
+	# Ignore.
+      end
     end
   end
-  
+
   after do
     stop_server
   end


### PR DESCRIPTION
This comprises two related changes:

- For individual servers, use --wait to timeout a start or stop effort.
- For clusters, pass the --wait parameter down to each cluster's stop/start/restart
  command.

(Fixes https://github.com/macournoyer/thin/issues/310)