### PR TITLE
Do not wait indefinitely for process to finish

### DIFF
--- a/lib/thin/controllers/controller.rb
+++ b/lib/thin/controllers/controller.rb
@@ -91,7 +91,7 @@ module Thin
         raise OptionRequired, :pid unless @options[:pid]
       
         tail_log(@options[:log]) do
-          if Server.kill(@options[:pid], @options[:force] ? 0 : (@options[:timeout] || 60))
+          if Server.kill(@options[:pid], (@options[:timeout] || 60), force: @options[:force])
             wait_for_file :deletion, @options[:pid]
           end
         end

--- a/lib/thin/daemonizing.rb
+++ b/lib/thin/daemonizing.rb
@@ -104,8 +104,8 @@ module Thin
       # PID is stored in +pid_file+.
       # If the process is still running after +timeout+, KILL signal is
       # sent.
-      def kill(pid_file, timeout=60)
-        if timeout == 0
+      def kill(pid_file, timeout=60, force: false)
+        if force
           send_signal('INT', pid_file, timeout)
         else
           send_signal('QUIT', pid_file, timeout)

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -107,10 +107,16 @@ describe Controller do
   end
   
   it "should stop" do
-    Server.should_receive(:kill).with('thin.pid', 10)
+    Server.should_receive(:kill).with('thin.pid', 10, force: nil)
     @controller.stop
   end
-  
+
+  it "should force stop" do
+    @controller.options[:force] = true
+    Server.should_receive(:kill).with('thin.pid', 10, force: true)
+    @controller.stop
+  end
+
   it "should restart" do
     Server.should_receive(:restart).with('thin.pid')
     @controller.restart

--- a/spec/daemonizing_spec.rb
+++ b/spec/daemonizing_spec.rb
@@ -110,7 +110,7 @@ describe 'Daemonizing' do
   
     timeout(10) do
       silence_stream STDOUT do
-        TestServer.kill(@server.pid_file, 0)
+        TestServer.kill(@server.pid_file, 60, force: true)
       end
     end
   


### PR DESCRIPTION
When stopping thin with `bundle exec thin stop -f`, it sets timeout to
0 and if process does not die on `SIGINT`, it will never send `SIGKILL`
because it waits idefinitely for it to die (`Timeout.timeout(0)`).