### PR TITLE
Fixnum is deprecated in upcoming ruby version

### DIFF
--- a/lib/thin/server.rb
+++ b/lib/thin/server.rb
@@ -104,9 +104,9 @@ module Thin
       # received in any order.
       args.each do |arg|
         case arg
-        when Fixnum, /^\d+$/ then port    = arg.to_i
-        when String          then host    = arg
-        when Hash            then options = arg
+        when 0.class, /^\d+$/ then port    = arg.to_i
+        when String           then host    = arg
+        when Hash             then options = arg
         else
           @app = arg if arg.respond_to?(:call)
         end


### PR DESCRIPTION
Fixnum and Bignum are being deprecated in ruby version 2.4
https://bugs.ruby-lang.org/issues/12739, use 0.class to
handle the transition