### PR TITLE
Fix duplicate invalid requests

### DIFF
--- a/lib/thin/request.rb
+++ b/lib/thin/request.rb
@@ -75,7 +75,9 @@ module Thin
     # Raises an +InvalidRequest+ if invalid.
     # Returns +true+ if the parsing is complete.
     def parse(data)
-      if @parser.finished?  # Header finished, can only be some more body
+      if data.size > 0 && finished? # headers and body already fully satisfied. more data is erroneous.
+        raise InvalidRequest, 'Content longer than specified'
+      elsif @parser.finished?  # Header finished, can only be some more body
         @body << data
       else                  # Parse more header using the super parser
         @data << data

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -36,6 +36,12 @@ describe Connection do
     @connection.receive_data('GET')
   end
 
+  it "should process at most once when request is larger than expected" do
+    @connection.should_receive(:process).at_most(1)
+    @connection.receive_data("POST / HTTP/1.1\r\nHost: localhost:3000\r\nContent-Length: 300\r\n\r\n")
+    10.times { @connection.receive_data('X' * 1_000) }
+  end
+
   it "should process" do
     @connection.process
   end

--- a/spec/request/parser_spec.rb
+++ b/spec/request/parser_spec.rb
@@ -203,17 +203,29 @@ EOS
 
     request.should validate_with_lint
   end
-  
-  
+
+
   it "should fails on heders larger then MAX_HEADER" do
     proc { R("GET / HTTP/1.1\r\nFoo: #{'X' * Request::MAX_HEADER}\r\n\r\n") }.should raise_error(InvalidRequest)
   end
-  
+
+  it "should fail when total request vastly exceeds specified CONTENT_LENGTH" do
+    proc do
+      R(<<-EOS, true)
+POST / HTTP/1.1
+Host: localhost:3000
+Content-Length: 300
+
+#{'X' * 300_000}
+EOS
+    end.should raise_error(InvalidRequest)
+  end
+
   it "should default SERVER_NAME to localhost" do
     request = R("GET / HTTP/1.1\r\n\r\n")
     request.env['SERVER_NAME'].should == "localhost"
   end
-  
+
   it 'should normalize http_fields' do
     [ "GET /index.html HTTP/1.1\r\nhos-t: localhost\r\n\r\n",
       "GET /index.html HTTP/1.1\r\nhOs_t: localhost\r\n\r\n",


### PR DESCRIPTION
If a request contains a lying `Content-Length` header and has a body that vastly exceeds the specified size then thin will invoke the connected app several times. Precisely, it will invoke the app once when the first chunk brings the body size above the specified `Content-Length` size. This will cause `Request#parse` to respond `true`. It will then invoke the app for every additional chunk received as `Request#parse` continues to respond `true`.

I could see this being fixed in `Request#parse` or `Connection#receive_data`. I chose the former, but included specs for both `Request` and `Connection` which demonstrate the bug when my change is not present.

Raising `InvalidRequest` could be done earlier and most strictly if it was placed later in `Request#parse` so it checks body size after the incoming chunk has been appended to the body. Doing it where I chose gives a little flexibility so if the content length is only mildly exceeded no error is thrown. Only on receipt of entire chunks beyond the content length is the request considered invalid.

This also may represent a small security fix as well. If the content length header specifies a small content but the client sends a large one then `Request#move_body_to_tempfile` will never be called and RAM usage can be ballooned by a malicious client, possibly compromising the server's stability.