### PR TITLE
Support RSpec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ end
 
 group :test do
   gem "rake", '< 11.0'
-  gem "rspec", "~> 1.2.9"
+  gem "rspec", "~> 3.5"
 end

--- a/spec/backends/swiftiply_client_spec.rb
+++ b/spec/backends/swiftiply_client_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Backends::SwiftiplyClient do
   before do
     @backend = Backends::SwiftiplyClient.new('0.0.0.0', 3333)
-    @backend.server = mock('server').as_null_object
+    @backend.server = double('server').as_null_object
   end
   
   it "should connect" do
@@ -26,7 +26,7 @@ describe SwiftiplyConnection do
   before do
     @connection = SwiftiplyConnection.new(nil)
     @connection.backend = Backends::SwiftiplyClient.new('0.0.0.0', 3333)
-    @connection.backend.server = mock('server').as_null_object
+    @connection.backend.server = double('server').as_null_object
   end
   
   it do
@@ -39,8 +39,8 @@ describe SwiftiplyConnection do
   end
   
   it "should reconnect on unbind" do
-    @connection.backend.stub!(:running?).and_return(true)
-    @connection.stub!(:rand).and_return(0) # Make sure we don't wait
+    allow(@connection.backend).to receive(:running?) { true }
+    allow(@connection).to receive(:rand) { 0 } # Make sure we don't wait
     
     @connection.should_receive(:reconnect).with('0.0.0.0', 3333)
     
@@ -51,7 +51,7 @@ describe SwiftiplyConnection do
   end
   
   it "should not reconnect when not running" do
-    @connection.backend.stub!(:running?).and_return(false)
+    allow(@connection.backend).to receive(:running?) { false }
     EventMachine.should_not_receive(:add_timer)
     @connection.unbind
   end

--- a/spec/backends/unix_server_spec.rb
+++ b/spec/backends/unix_server_spec.rb
@@ -22,7 +22,7 @@ describe Backends::UnixServer do
   
   it "should remove socket file on close" do
     @backend.close
-    File.exist?('/tmp/thin-test.sock').should be_false
+    File.exist?('/tmp/thin-test.sock').should be_falsey
   end
 end
 

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -18,7 +18,7 @@ describe Controller, 'start' do
     
     Server.should_receive(:new).with('0.0.0.0', 3000, @controller.options).and_return(@server)
     @server.should_receive(:config)
-    Rack::Adapter::Rails.stub!(:new).and_return(@adapter)
+    allow(Rack::Adapter::Rails).to receive(:new) { @adapter }
   end
   
   it "should configure server" do
@@ -87,7 +87,7 @@ describe Controller, 'start' do
     @controller.options[:threaded] = true
     @controller.start
     
-    @server.threaded.should be_true
+    @server.threaded.should be_truthy
   end
   
   it "should set RACK_ENV" do
@@ -103,7 +103,7 @@ end
 describe Controller do
   before do
     @controller = Controller.new(:pid => 'thin.pid', :timeout => 10)
-    @controller.stub!(:wait_for_file)
+    allow(@controller).to receive(:wait_for_file)
   end
   
   it "should stop" do

--- a/spec/controllers/service_spec.rb
+++ b/spec/controllers/service_spec.rb
@@ -10,7 +10,7 @@ describe Service do
   end
 
   before do
-    Thin.stub!(:linux?).and_return(true)
+    allow(Thin).to receive(:linux?) { true }
     FileUtils.mkdir_p 'tmp/sandbox'
 
     @service = Service.new(:all => 'spec/configs')
@@ -27,7 +27,7 @@ describe Service do
   it "should create /etc/init.d/thin file when calling install" do
     @service.install
 
-    File.exist?(Service::INITD_PATH).should be_true
+    File.exist?(Service::INITD_PATH).should be_truthy
     script_name = File.directory?('/etc/rc.d') ?
       '/etc/rc.d/thin' : '/etc/init.d/thin'
     File.read(Service::INITD_PATH).should include('CONFIG_PATH=tmp/sandbox/etc/thin',
@@ -38,7 +38,7 @@ describe Service do
   it "should create /etc/thin dir when calling install" do
     @service.install
 
-    File.directory?(Service::DEFAULT_CONFIG_PATH).should be_true
+    File.directory?(Service::DEFAULT_CONFIG_PATH).should be_truthy
   end
 
   it "should include specified path in /etc/init.d/thin script" do

--- a/spec/daemonizing_spec.rb
+++ b/spec/daemonizing_spec.rb
@@ -42,7 +42,7 @@ describe 'Daemonizing' do
     
     sleep 1
     Process.wait(@pid)
-    File.exist?(@server.pid_file).should be_true
+    File.exist?(@server.pid_file).should be_truthy
     @pid = @server.pid
 
     proc { sleep 0.1 while File.exist?(@server.pid_file) }.should take_less_then(20)
@@ -77,7 +77,7 @@ describe 'Daemonizing' do
   end
   
   it 'should kill process in pid file' do
-    File.exist?(@server.pid_file).should be_false
+    File.exist?(@server.pid_file).should be_falsey
     
     @pid = fork do
       @server.daemonize
@@ -94,7 +94,7 @@ describe 'Daemonizing' do
     
     Process.wait(@pid)
     
-    File.exist?(@server.pid_file).should be_false
+    File.exist?(@server.pid_file).should be_falsey
   end
   
   it 'should force kill process in pid file' do
@@ -113,7 +113,7 @@ describe 'Daemonizing' do
     
     Process.wait(@pid)
     
-    File.exist?(@server.pid_file).should be_false
+    File.exist?(@server.pid_file).should be_falsey
   end
   
   it 'should send kill signal if timeout' do
@@ -131,8 +131,8 @@ describe 'Daemonizing' do
     
     Process.wait(@pid)
     
-    File.exist?(@server.pid_file).should be_false
-    Process.running?(@pid).should be_false
+    File.exist?(@server.pid_file).should be_falsey
+    Process.running?(@pid).should be_falsey
   end
   
   it "should restart" do
@@ -174,7 +174,7 @@ describe 'Daemonizing' do
 
     proc { @server.daemonize }.should raise_error(PidFileExist)
     
-    File.exist?(@server.pid_file).should be_true
+    File.exist?(@server.pid_file).should be_truthy
   end
   
   it "should raise if no pid file" do
@@ -189,7 +189,7 @@ describe 'Daemonizing' do
     
     @server.send(:remove_stale_pid_file)
     
-    File.exist?(@server.pid_file).should be_false
+    File.exist?(@server.pid_file).should be_falsey
   end
   
   after do

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -22,7 +22,7 @@ describe Logging do
   describe "when setting a custom logger" do
 
     it "should not accept a logger object that is not sane" do
-      expect { Logging.logger = "" }.to raise_error
+      expect { Logging.logger = "" }.to raise_error(ArgumentError)
     end
 
     it "should accept a legit custom logger object" do
@@ -54,7 +54,7 @@ describe Logging do
 
       str = nil
       expect { str = @readpipe.read_nonblock(512) }.to_not raise_error
-      str.should_not be_nil
+      expect(str).not_to be_nil
     end
 
     #
@@ -63,7 +63,9 @@ describe Logging do
       Logging.debug = false
       @object.log_debug("hiya")
 
-      expect { @readpipe.read_nonblock(512) }.to raise_error
+      expect do
+        @readpipe.read_nonblock(512)
+      end.to raise_error(IO::EAGAINWaitReadable)
     end
 
     #
@@ -78,19 +80,25 @@ describe Logging do
     it "should not log messages if silenced via module method" do
       Logging.silent = true
       @object.log_info("hola")
-      expect { @readpipe.read_nonblock(512) }.to raise_error()
+      expect do
+        @readpipe.read_nonblock(512)
+      end.to raise_error(IO::EAGAINWaitReadable)
     end
 
     it "should not log anything if silenced via module methods" do
       Logging.silent = true
       Logging.log_msg("hi")
-      expect { @readpipe.read_nonblock(512) }.to raise_error()
+      expect do
+        @readpipe.read_nonblock(512)
+      end.to raise_error(IO::EAGAINWaitReadable)
     end
 
     it "should not log anything if silenced via instance methods" do
       @object.silent = true
       @object.log_info("hello")
-      expect { @readpipe.read_nonblock(512) }.to raise_error()
+      expect do
+        @readpipe.read_nonblock(512)
+      end.to raise_error(IO::EAGAINWaitReadable)
     end
 
   end # Logging tests (with custom logger)
@@ -103,8 +111,8 @@ describe Logging do
         @object.log_debug("Hey")
       end
 
-      out.include?("Hey").should be_true
-      out.include?("DEBUG").should be_true
+      out.include?("Hey").should be_truthy
+      out.include?("DEBUG").should be_truthy
     end
 
     it "should be usable (at the module level) for logging" do
@@ -112,7 +120,7 @@ describe Logging do
         Logging.log_msg("Hey")
       end
 
-      out.include?("Hey").should be_true
+      out.include?("Hey").should be_truthy
     end
 
   end
@@ -147,7 +155,7 @@ describe Logging do
         @object.trace("Hey")
       end
 
-      out.include?("Hey").should be_true
+      out.include?("Hey").should be_truthy
     end
 
     it "should be usable (at the module level) for logging" do
@@ -156,7 +164,7 @@ describe Logging do
         Logging.trace_msg("hey")
       end
 
-      out.include?("hey").should be_true
+      out.include?("hey").should be_truthy
     end
 
   end # tracer tests (no custom logger)

--- a/spec/request/processing_spec.rb
+++ b/spec/request/processing_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Request, 'processing' do
   it 'should parse in chunks' do
     request = Request.new
-    request.parse("POST / HTTP/1.1\r\n").should be_false
-    request.parse("Host: localhost\r\n").should be_false
-    request.parse("Content-Length: 9\r\n").should be_false
-    request.parse("\r\nvery ").should be_false
-    request.parse("cool").should be_true
+    request.parse("POST / HTTP/1.1\r\n").should be_falsey
+    request.parse("Host: localhost\r\n").should be_falsey
+    request.parse("Content-Length: 9\r\n").should be_falsey
+    request.parse("\r\nvery ").should be_falsey
+    request.parse("cool").should be_truthy
 
     request.env['CONTENT_LENGTH'].should == '9'
     request.body.read.should == 'very cool'
@@ -46,9 +46,9 @@ describe Request, 'processing' do
     request.parse("Content-Length: #{body.size}\r\n\r\n")
     request.parse(body)
 
-    request.body.closed?.should be_false
+    request.body.closed?.should be_falsey
     request.close
-    request.body.closed?.should be_true
+    request.body.closed?.should be_truthy
   end
 
   it "should raise error when header is too big" do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -35,7 +35,7 @@ describe Runner do
   it "should use Controller when controlling a single server" do
     runner = Runner.new(%w(start))
 
-    controller = mock('controller')
+    controller = double('controller')
     controller.should_receive(:start)
     Controllers::Controller.should_receive(:new).and_return(controller)
 
@@ -45,7 +45,7 @@ describe Runner do
   it "should use Cluster controller when controlling multiple servers" do
     runner = Runner.new(%w(start --servers 3))
 
-    controller = mock('cluster')
+    controller = double('cluster')
     controller.should_receive(:start)
     Controllers::Cluster.should_receive(:new).and_return(controller)
 
@@ -86,16 +86,16 @@ describe Runner do
 
   it "should remember debug options" do
     runner = Runner.new(%w(start -D -q -V))
-    runner.options[:debug].should be_true
-    runner.options[:quiet].should be_true
-    runner.options[:trace].should be_true
+    runner.options[:debug].should be_truthy
+    runner.options[:quiet].should be_truthy
+    runner.options[:trace].should be_truthy
   end
 
   it "should default debug, silent and trace to false" do
     runner = Runner.new(%w(start))
-    runner.options[:debug].should_not be_true
-    runner.options[:quiet].should_not be_true
-    runner.options[:trace].should_not be_true
+    runner.options[:debug].should_not be_truthy
+    runner.options[:quiet].should_not be_truthy
+    runner.options[:trace].should_not be_truthy
   end
 end
 
@@ -125,7 +125,7 @@ describe Runner, 'with config file' do
   it "should change directory after loading config" do
     @orig_dir = Dir.pwd
 
-    controller = mock('controller')
+    controller = double('controller')
     controller.should_receive(:respond_to?).with('start').and_return(true)
     controller.should_receive(:start)
     Controllers::Cluster.should_receive(:new).and_return(controller)
@@ -147,10 +147,10 @@ end
 
 describe Runner, "service" do
   before do
-    Thin.stub!(:linux?).and_return(true)
+    allow(Thin).to receive(:linux?) { true }
 
-    @controller = mock('service')
-    Controllers::Service.stub!(:new).and_return(@controller)
+    @controller = double('service')
+    allow(Controllers::Service).to receive(:new) { @controller }
   end
 
   it "should use Service controller when controlling all servers" do
@@ -172,7 +172,7 @@ describe Runner, "service" do
   it "should call install without arguments" do
     runner = Runner.new(%w(install))
 
-    @controller.should_receive(:install).with()
+    @controller.should_receive(:install).with(no_args)
 
     runner.run!
   end

--- a/spec/server/unix_socket_spec.rb
+++ b/spec/server/unix_socket_spec.rb
@@ -17,7 +17,7 @@ describe Server, "on UNIX domain socket" do
   
   it "should remove socket file after server stops" do
     @server.stop!
-    File.exist?('/tmp/thin_test.sock').should be_false
+    File.exist?('/tmp/thin_test.sock').should be_falsey
   end
   
   after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -253,7 +253,7 @@ module Helpers
   end
 end
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   config.include Matchers
   config.include Helpers
 end

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,7 +1,6 @@
 CLEAN.include %w(coverage tmp log)
 
-gem "rspec", "~> 1.2.9"
-require 'spec/rake/spectask'
+require 'rspec/core/rake_task'
 
 PERF_SPECS = FileList['spec/perf/*_spec.rb']
 WIN_SPECS  = %w(
@@ -22,9 +21,9 @@ SPEC_GROUPS = [
 SPECS = FileList['spec/**/*_spec.rb'] - PERF_SPECS - SPEC_GROUPS.flatten
 
 def spec_task(name, specs)
-  Spec::Rake::SpecTask.new(name) do |t|
-    t.spec_opts = %w(-fs -c)
-    t.spec_files = specs
+  RSpec::Core::RakeTask.new(name) do |t|
+    t.rspec_opts = ["-c", "-f progress"]
+    t.pattern = specs
   end
 end
 

--- a/thin.gemspec
+++ b/thin.gemspec
@@ -4,7 +4,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "thin/version"
 
 # Describe your gem and declare its dependencies:
-Thin::GemSpec = Gem::Specification.new do |s|
+Thin::GemSpec ||= Gem::Specification.new do |s|
   s.name                  = Thin::NAME
   s.version               = Thin::VERSION::STRING
   s.platform              = Thin.win? ? Gem::Platform::CURRENT : Gem::Platform::RUBY


### PR DESCRIPTION
I would send patch to use RSpec3.

Let me check the result of Travis with this PR, as I fixed mostly, but still not perfect (2 failures)
I want to know whether the 2 failures depend on Ruby version or not, as I am using new version Ruby 2.4.0.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.14.3

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * bundler (1.14.3)
  * daemons (1.2.4)
  * diff-lcs (1.3)
  * eventmachine (1.2.3)
  * rack (2.0.1)
  * rake (12.0.0)
  * rake-compiler (1.0.3)
  * rspec (3.5.0)
  * rspec-core (3.5.4)
  * rspec-expectations (3.5.0)
  * rspec-mocks (3.5.0)
  * rspec-support (3.5.0)
  * thin (1.7.0)

$ bundle exec rake spec
...
[2017-03-02T22:11:15.056429 #17551]  INFO -- : Hey
[2017-03-02T22:11:15.065435 #17551]  INFO -- : hey
...
Failures:

  1) Thin::Logging tracing routines (with NO custom logger) should emit trace messages if tracing is enabled 
     Failure/Error: out.include?("Hey").should be_truthy
     
       expected: truthy value
            got: false
     # ./spec/logging_spec.rb:158:in `block (3 levels) in <top (required)>'

  2) Thin::Logging tracing routines (with NO custom logger) should be usable (at the module level) for logging
     Failure/Error: out.include?("hey").should be_truthy
     
       expected: truthy value
            got: false
     # ./spec/logging_spec.rb:167:in `block (3 levels) in <top (required)>'
...
197 examples, 2 failures
```






Thanks.
