### PR TITLE
Add source code and changelog links to gemspec

### DIFF
--- a/thin.gemspec
+++ b/thin.gemspec
@@ -17,6 +17,11 @@ Thin::GemSpec = Gem::Specification.new do |s|
   s.licenses              = ["GPLv2+", "Ruby 1.8"]
   s.executables           = %w( thin )
 
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/macournoyer/thin',
+    'changelog_uri'   => 'https://github.com/macournoyer/thin/blob/master/CHANGELOG'
+  }
+
   s.required_ruby_version = '>= 1.8.5'
   
   s.add_dependency        'rack',         '>= 1', '< 3'


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `thin`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `thin` source code when it creates PRs. Without that link, we generate PRs like [this one](https://github.com/greysteil/onebody/pull/20), rather than PRs like [this one](https://github.com/greysteil/onebody/pull/12).)