### PR TITLE
Mock Kernel.warn in Ruby 2.5 compatible way.

### DIFF
--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -65,10 +65,10 @@ describe Runner do
   end
 
   it "should warn when require a rack config file" do
-    STDERR.stub!(:write)
-    STDERR.should_receive(:write).with(/WARNING:/)
-
     runner = Runner.new(%w(start -r config.ru))
+
+    runner.should_receive(:warn).with(/WARNING:/)
+
     runner.run! rescue nil
 
     runner.options[:rackup].should == 'config.ru'


### PR DESCRIPTION
Ruby changed the way Kernel#warn reports the error [1], but mocking the
method on the class, which is calling it, should be universal [2].

[1] https://bugs.ruby-lang.org/issues/12944
[2] https://www.reddit.com/r/ruby/comments/2nki9q/rspec_how_do_you_mock_or_stub_kernel_methods_like/