### PR TITLE
Fix persistent status when response does not have a body

### DIFF
--- a/lib/thin/response.rb
+++ b/lib/thin/response.rb
@@ -7,7 +7,8 @@ module Thin
     SERVER         = 'Server'.freeze
     CONTENT_LENGTH = 'Content-Length'.freeze
 
-    PERSISTENT_STATUSES  = [100, 101].freeze
+    PERSISTENT_STATUSES          = [100, 101].freeze
+    STATUSES_WITH_NO_ENTITY_BODY = [204, 304].freeze
 
     #Error Responses
     ERROR            = [500, {'Content-Type' => 'text/plain'}, ['Internal server error']].freeze
@@ -107,7 +108,8 @@ module Thin
     # from the server and have a Content-Length, or the response
     # status must require that the connection remain open.
     def persistent?
-      (@persistent && @headers.has_key?(CONTENT_LENGTH)) || PERSISTENT_STATUSES.include?(@status)
+      (@persistent && (@headers.has_key?(CONTENT_LENGTH) || STATUSES_WITH_NO_ENTITY_BODY.include?(@status))) ||
+        PERSISTENT_STATUSES.include?(@status)
     end
 
     def skip_body!

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -89,6 +89,16 @@ describe Response do
     @response.should be_persistent
   end
 
+  it "should ignore Content-Length when response does not have a body" do
+    @response = Response.new
+    @response.headers = {'Content-Type' => 'text/html'}
+    @response.body = ''
+    @response.status = 204
+
+    @response.persistent!
+    @response.should be_persistent
+  end
+
   it "should be persistent when the status code implies it should stay open" do
     @response = Response.new
     @response.status = 100


### PR DESCRIPTION
[Rack::ContentLength][1] does not add Content-Length header when the
response status code is 204 or 304. Here we immediately closed the
connection when Content-Length was missing. This commit adds exception
for responses without a body (statuses 204 & 304) similarly to
Rack::ContentLength.

[1]: https://github.com/rack/rack/blob/master/lib/rack/content_length.rb