### PR TITLE
Silence Ruby warnings for un-initialized ivars

### DIFF
--- a/lib/thin/backends/base.rb
+++ b/lib/thin/backends/base.rb
@@ -51,9 +51,11 @@ module Thin
         @maximum_connections            = Server::DEFAULT_MAXIMUM_CONNECTIONS
         @maximum_persistent_connections = Server::DEFAULT_MAXIMUM_PERSISTENT_CONNECTIONS
         @no_epoll                       = false
+        @running                        = false
         @ssl                            = nil
-        @threaded                       = nil
         @started_reactor                = false
+        @stopping                       = false
+        @threaded                       = nil
       end
       
       # Start the backend and connect it.


### PR DESCRIPTION
Specifically `@running`, but it seems sensible to also init `@stopping` since they are a bit of a tandem.