### PR TITLE
fix: update parser header file with namespaced functions

### DIFF
--- a/ext/thin_parser/parser.h
+++ b/ext/thin_parser/parser.h
@@ -38,11 +38,11 @@ typedef struct http_parser {
   
 } http_parser;
 
-int http_parser_init(http_parser *parser);
-int http_parser_finish(http_parser *parser);
-size_t http_parser_execute(http_parser *parser, const char *data, size_t len, size_t off);
-int http_parser_has_error(http_parser *parser);
-int http_parser_is_finished(http_parser *parser);
+int thin_http_parser_init(http_parser *parser);
+int thin_http_parser_finish(http_parser *parser);
+size_t thin_http_parser_execute(http_parser *parser, const char *data, size_t len, size_t off);
+int thin_http_parser_has_error(http_parser *parser);
+int thin_http_parser_is_finished(http_parser *parser);
 
 #define http_parser_nread(parser) (parser)->nread 
 


### PR DESCRIPTION
https://github.com/macournoyer/thin/commit/d5b523e6fda527588c690b5f37c25893c1cd0701 renamed the parser functions to include a `thin_` prefix as a namespace, but did not update the parser header file. This did not cause any problems for a long time because `implicit-function-declaration` was just a warning previously, but [Xcode 12 has made it an error](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-beta-release-notes#Updates-in-Xcode-12-Beta) (second bullet under Apple Clang Compiler > Resolved):

> Clang now reports an error when you use a function without an explicit declaration when building C or Objective-C code for macOS (-Werror=implicit-function-declaration flag is on). This additional error detection unifies Clang’s behavior for iOS/tvOS and macOS 64-bit targets for this diagnostic. (49917738)

This is preventing install of this gem on macOS with Xcode 12.

Note: there *is* a workaround until this is patched:
```sh
$ gem install thin -- --with-cflags="-Wno-error=implicit-function-declaration"
```
or with Bundler:
```sh
$ bundle config build.thin --with-cflags="-Wno-error=implicit-function-declaration"
```