### PR TITLE
Address 'error: implicit declaration of function' by setting prototypes

### DIFF
--- a/ext/thin_parser/parser.h
+++ b/ext/thin_parser/parser.h
@@ -43,6 +43,12 @@ int http_parser_finish(http_parser *parser);
 size_t http_parser_execute(http_parser *parser, const char *data, size_t len, size_t off);
 int http_parser_has_error(http_parser *parser);
 int http_parser_is_finished(http_parser *parser);
+int thin_http_parser_init(http_parser *parser);
+int thin_http_parser_finish(http_parser *parser);
+int thin_http_parser_is_finished(http_parser *parser);
+size_t thin_http_parser_execute(http_parser *parser, const char *buffer, size_t len, size_t off);
+static const int http_parser_en_main;
+int thin_http_parser_has_error(http_parser *parser);
 
 #define http_parser_nread(parser) (parser)->nread 
 


### PR DESCRIPTION
This pull request fixes #365, so that macOS 11.0 Big Sur beta and 10.15.6 Catalina users can install thin gem.

I have just googled and found this error can be addressed by setting "prototype" in advance like https://stackoverflow.com/questions/8440816/warning-implicit-declaration-of-function .