### PR TITLE
Fix possible HTTP Response Splitting

### DIFF
--- a/lib/thin/headers.rb
+++ b/lib/thin/headers.rb
@@ -4,6 +4,7 @@ module Thin
   class Headers
     HEADER_FORMAT      = "%s: %s\r\n".freeze
     ALLOWED_DUPLICATES = %w(set-cookie set-cookie2 warning www-authenticate).freeze
+    CR_OR_LF           = /[\r\n]/.freeze
     
     def initialize
       @sent = {}
@@ -20,7 +21,7 @@ module Thin
         value = case value
                 when Time
                   value.httpdate
-                when NilClass
+                when NilClass, CR_OR_LF
                   return
                 else
                   value.to_s

--- a/lib/thin/headers.rb
+++ b/lib/thin/headers.rb
@@ -1,4 +1,8 @@
 module Thin
+  # Raised when an header is not valid
+  # and the server can not process it.
+  class InvalidHeader < StandardError; end
+
   # Store HTTP header name-value pairs direcly to a string
   # and allow duplicated entries on some names.
   class Headers
@@ -21,8 +25,10 @@ module Thin
         value = case value
                 when Time
                   value.httpdate
-                when NilClass, CR_OR_LF
+                when NilClass
                   return
+                when CR_OR_LF
+                  raise InvalidHeader, "Header contains CR or LF"
                 else
                   value.to_s
                 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -44,17 +44,14 @@ describe Headers do
   end
 
   it 'should not allow CRLF' do
-    @headers['Bad'] = "a\r\nSet-Cookie: injected=value"
-    expect(@headers.to_s).to be_empty
+    expect { @headers['Bad'] = "a\r\nSet-Cookie: injected=value" }.to raise_error(InvalidHeader)
   end
 
   it 'should not allow CR' do
-    @headers['Bad'] = "a\rSet-Cookie: injected=value"
-    expect(@headers.to_s).to be_empty
+    expect { @headers['Bad'] = "a\rSet-Cookie: injected=value" }.to raise_error(InvalidHeader)
   end
 
   it 'should not allow LF' do
-    @headers['Bad'] = "a\nSet-Cookie: injected=value"
-    expect(@headers.to_s).to be_empty
+    expect { @headers['Bad'] = "a\nSet-Cookie: injected=value" }.to raise_error(InvalidHeader)
   end
 end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -37,4 +37,24 @@ describe Headers do
     @headers['Modified-At'] = time
     expect(@headers.to_s).to include("Modified-At: #{time.httpdate}")
   end
+
+  it 'should format Integer values correctly' do
+    @headers['X-Number'] = 32
+    expect(@headers.to_s).to include("X-Number: 32")
+  end
+
+  it 'should not allow CRLF' do
+    @headers['Bad'] = "a\r\nSet-Cookie: injected=value"
+    expect(@headers.to_s).to be_empty
+  end
+
+  it 'should not allow CR' do
+    @headers['Bad'] = "a\rSet-Cookie: injected=value"
+    expect(@headers.to_s).to be_empty
+  end
+
+  it 'should not allow LF' do
+    @headers['Bad'] = "a\nSet-Cookie: injected=value"
+    expect(@headers.to_s).to be_empty
+  end
 end


### PR DESCRIPTION
Ignore any response header with `\r` or `\n` in their value.

See https://github.com/advisories/GHSA-84j7-475p-hp8v