### PR TITLE
Increase timeout when checking for server stop

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,7 +201,7 @@ module Helpers
     @server.stop!
     @thread.kill
     
-    100.times do
+    1000.times do
       break unless EM.reactor_running?
       sleep 0.01
     end


### PR DESCRIPTION
On Ubuntu Impish (development version), we're currently facing a
problem where thin's testsuite fails when it runs on an armhf system.
After some investigation, I noticed that the reason for this failure
was that the server was still running even after the loop on
`spec/spec_helper.rb:stop_server`.

Given that the loop is actively checking to see if the server has
stopped, I'd like to propose that the timeout be increased from 1
second to 10 seconds.  Although I'm not a fan of the
"let's-just-increase-the-timeout" type of solutions, in this
particular case I think it's justified and makes sense (1 second may
indeed be too quick for the server to properly stop).