### PR TITLE
Support rack 3.x and rackup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         ruby:
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
           - 3.1
           - 3.2
           - 3.3
@@ -46,10 +46,18 @@ jobs:
             os: macos
             ruby: 3.4
             gemfile: gems/rack-v2.rb
+          - experimental: false
+            os: macos
+            ruby: 3.4
+            gemfile: gems/rack-v3.rb
           - experimental: true
             os: ubuntu
             ruby: head
             gemfile: gems/rack-v2.rb
+          - experimental: true
+            os: ubuntu
+            ruby: head
+            gemfile: gems/rack-v3.rb
           - experimental: true
             os: ubuntu
             ruby: 3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,9 @@ jobs:
           - 3.4
 
         gemfile:
+          - gems/rack-v1.rb
           - gems/rack-v2.rb
+          - gems/rack-v3.rb
 
         include:
           - experimental: false
@@ -50,23 +52,14 @@ jobs:
             gemfile: gems/rack-v2.rb
           - experimental: true
             os: ubuntu
-            ruby: 2.7
-            gemfile: gems/rack-v1.rb
-          - experimental: true
-            os: ubuntu
-            ruby: 3.4
-            gemfile: gems/rack-v2.rb
-          - experimental: true
-            os: ubuntu
-            ruby: 3.4
-            gemfile: gems/rack-v3.rb
-          - experimental: true
-            os: ubuntu
             ruby: 3.4
             gemfile: gems/rack-head.rb
+        exclude:
+          - { ruby: 3.3, gemfile: gems/rack-v1.rb }
+          - { ruby: 3.4, gemfile: gems/rack-v1.rb }
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/gems/rack-head.rb
+++ b/gems/rack-head.rb
@@ -3,3 +3,4 @@
 eval_gemfile "../Gemfile"
 
 gem 'rack', github: 'rack/rack'
+gem 'rackup'

--- a/gems/rack-v3.rb
+++ b/gems/rack-v3.rb
@@ -3,3 +3,4 @@
 eval_gemfile "../Gemfile"
 
 gem 'rack', "~> 3.0"
+gem 'rackup'

--- a/lib/rack/handler/thin.rb
+++ b/lib/rack/handler/thin.rb
@@ -32,7 +32,22 @@ module Rack
         }
       end
     end
-
-    register :thin, ::Rack::Handler::Thin
   end
+end
+
+# rackup was removed in Rack 3, it is now a separate gem
+if Object.const_defined?(:Rackup) && ::Rackup.const_defined?(:Handler)
+  module Rackup
+    module Handler
+      module Thin
+        class << ::Rack::Handler::Thin
+        end
+      end
+
+      register :thin, ::Rackup::Handler::Thin
+    end
+  end
+else
+  do_register = Object.const_defined?(:Rack) && ::Rack.release < '3'
+  ::Rack::Handler.register(:thin, ::Rack::Handler::Thin) if do_register
 end

--- a/lib/rackup/handler/thin.rb
+++ b/lib/rackup/handler/thin.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'rack/handler'
+require 'rackup/handler'
 require_relative '../../thin/rackup/handler'
 
-module Rack
+module Rackup
   module Handler
     class Thin < ::Thin::Rackup::Handler
     end
 
-    register :thin, Thin.to_s
+    register :thin, Thin
   end
 end

--- a/lib/thin/rackup/handler.rb
+++ b/lib/thin/rackup/handler.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Thin
+  module Rackup
+    class Handler
+      def self.run(app, **options)
+        environment  = ENV['RACK_ENV'] || 'development'
+        default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
+
+        host = options.delete(:Host) || default_host
+        port = options.delete(:Port) || 8080
+        args = [host, port, app, options]
+
+        server = ::Thin::Server.new(*args)
+        yield server if block_given?
+
+        server.start
+      end
+
+      def self.valid_options
+        environment  = ENV['RACK_ENV'] || 'development'
+        default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
+
+        {
+          "Host=HOST" => "Hostname to listen on (default: #{default_host})",
+          "Port=PORT" => "Port to listen on (default: 8080)",
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello,

following what have been done in https://github.com/macournoyer/thin/pull/399 I was trying to see if I was able to upgrade resque ( https://github.com/resque/resque/pull/1912 ) to support rack 3.x. As it wasn't working, digging a little I think `thin` is missing one last bit in order to be able to work both with rack 2/3 and with/without rackup gem. I've taken inspiration on what has been done in puma https://github.com/puma/puma/pull/3532.

Thanks,
Andrea