### PR TITLE
Fixed link to the Ruby license

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tag: a-name-to-show-up-in-ps aux
 
 ## License
 
-Ruby License, http://www.ruby-lang.org/en/LICENSE.txt.
+Ruby License, https://www.ruby-lang.org/en/about/license.txt.
 
 ## Credits
 


### PR DESCRIPTION
The current link to the Ruby license gives a 404. I only replaced that link.