### PR TITLE
Fix "No such file or directory @ rb_io_reopen" error from test.

### DIFF
--- a/spec/daemonizing_spec.rb
+++ b/spec/daemonizing_spec.rb
@@ -77,12 +77,10 @@ describe 'Daemonizing' do
   
   it 'should change privilege' do
     pid = fork do
-      subject.daemonize
       subject.change_privilege('root', 'admin')
     end
 
     _, status = Process.wait2(pid)
-
     expect(status).to be_a_success
   end
   


### PR DESCRIPTION
```
> bundle exec rspec spec/daemonizing_spec.rb -fd

Daemonizing
  should have a pid file
  should create a pid file
  should redirect stdio to a log file
  should change privilege
/Users/samuel/.gem/ruby/3.4.4/gems/daemons-1.4.1/lib/daemons/daemonize.rb:157:in 'IO#reopen': No such file or directory @ rb_io_reopen - /var/folders/cm/p8lkj40s0vz_vgx_b5df9dkm0000gn/T/d20250621-29968-3zseqz/test_server.log (Errno::ENOENT)
  from /Users/samuel/.gem/ruby/3.4.4/gems/daemons-1.4.1/lib/daemons/daemonize.rb:157:in 'Daemonize.redirect_io'
  from /Users/samuel/.gem/ruby/3.4.4/gems/daemons-1.4.1/lib/daemons/daemonize.rb:112:in 'Daemonize.daemonize'
  from /Users/samuel/Developer/macournoyer/thin/lib/thin/daemonizing.rb:58:in 'Thin::Daemonizable#daemonize'
  from /Users/samuel/Developer/macournoyer/thin/spec/daemonizing_spec.rb:80:in 'block (3 levels) in <top (required)>'
  from /Users/samuel/Developer/macournoyer/thin/spec/daemonizing_spec.rb:79:in 'Kernel#fork'
  from /Users/samuel/Developer/macournoyer/thin/spec/daemonizing_spec.rb:79:in 'block (2 levels) in <top (required)>'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:263:in 'BasicObject#instance_exec'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:263:in 'block in RSpec::Core::Example#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:511:in 'block in RSpec::Core::Example#with_around_and_singleton_context_hooks'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:468:in 'block in RSpec::Core::Example#with_around_example_hooks'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/hooks.rb:486:in 'block in RSpec::Core::Hooks::HookCollections#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/hooks.rb:626:in 'block in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
  from /Users/samuel/Developer/macournoyer/thin/spec/daemonizing_spec.rb:29:in 'block (3 levels) in <top (required)>'
  from /Users/samuel/.rubies/ruby-3.4.4/lib/ruby/3.4.0/tmpdir.rb:105:in 'Dir.mktmpdir'
  from /Users/samuel/Developer/macournoyer/thin/spec/daemonizing_spec.rb:23:in 'block (2 levels) in <top (required)>'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/hooks.rb:629:in 'RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/hooks.rb:486:in 'RSpec::Core::Hooks::HookCollections#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:468:in 'RSpec::Core::Example#with_around_example_hooks'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:511:in 'RSpec::Core::Example#with_around_and_singleton_context_hooks'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:259:in 'RSpec::Core::Example#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example_group.rb:653:in 'block in RSpec::Core::ExampleGroup.run_examples'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example_group.rb:649:in 'Array#map'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example_group.rb:649:in 'RSpec::Core::ExampleGroup.run_examples'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/example_group.rb:614:in 'RSpec::Core::ExampleGroup.run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:121:in 'block (3 levels) in RSpec::Core::Runner#run_specs'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:121:in 'Array#map'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:121:in 'block (2 levels) in RSpec::Core::Runner#run_specs'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/configuration.rb:2097:in 'RSpec::Core::Configuration#with_suite_hooks'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:116:in 'block in RSpec::Core::Runner#run_specs'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/reporter.rb:74:in 'RSpec::Core::Reporter#report'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:115:in 'RSpec::Core::Runner#run_specs'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:89:in 'RSpec::Core::Runner#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:71:in 'RSpec::Core::Runner.run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/lib/rspec/core/runner.rb:45:in 'RSpec::Core::Runner.invoke'
  from /Users/samuel/.gem/ruby/3.4.4/gems/rspec-core-3.13.4/exe/rspec:4:in '<top (required)>'
  from /Users/samuel/.gem/ruby/3.4.4/bin/rspec:25:in 'Kernel#load'
  from /Users/samuel/.gem/ruby/3.4.4/bin/rspec:25:in '<top (required)>'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:59:in 'Kernel.load'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/cli.rb:452:in 'Bundler::CLI#exec'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/exe/bundle:28:in 'block in <top (required)>'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
  from /Users/samuel/.gem/ruby/3.4.4/gems/bundler-2.6.2/exe/bundle:20:in '<top (required)>'
  from /Users/samuel/.gem/ruby/3.4.4/bin/bundle:25:in 'Kernel#load'
  from /Users/samuel/.gem/ruby/3.4.4/bin/bundle:25:in '<main>'
  should kill process in pid file
  should force kill process in pid file
  should send kill signal if timeout
  should restart
  should ignore if no restart block specified
  should not restart when not running
  should exit and raise if pid file already exist
  should raise if no pid file
  should should delete pid file if stale

Finished in 6.26 seconds (files took 0.10698 seconds to load)
13 examples, 0 failures
```